### PR TITLE
fix(ci): skip verify:changesets on tag pushes

### DIFF
--- a/scripts/verify-changesets.ts
+++ b/scripts/verify-changesets.ts
@@ -74,6 +74,17 @@ function main(): void {
   const root = repoRoot();
   process.chdir(root);
 
+  // Tag pushes (release workflow) run on detached HEAD with
+  // GITHUB_REF = refs/tags/v* — there is no PR diff to score, and the
+  // changeset was validated when the PR originally landed. A shallow
+  // checkout here also lacks origin/main so `git rev-parse HEAD~1`
+  // fails. Skip cleanly.
+  const ref = process.env.GITHUB_REF ?? "";
+  if (ref.startsWith("refs/tags/")) {
+    console.log(`verify:changesets — skipped on tag push (${ref})`);
+    process.exit(0);
+  }
+
   const branch = currentBranch();
   if (branch === "main" || branch === "master") {
     console.log("verify:changesets — skipped on default branch");


### PR DESCRIPTION
## Problem

The v0.212.1 Release workflow went red on `npm run verify`:

```
fatal: ambiguous argument 'HEAD~1...HEAD': unknown revision or path not in the working tree.
Error: git failed: git diff --name-only HEAD~1...HEAD
```

`scripts/verify-changesets.ts` was designed as a PR-scope gate ("did production src/ change without a changeset?"). Tag pushes from `release.yml` hit the same script via `npm run verify`, but:

- `GITHUB_REF_NAME` = the tag name (`v0.212.1`), not `main` → the "skip on default branch" early-return doesn't fire.
- `actions/checkout` default fetch-depth = 1, so `origin/main` and `HEAD~1` don't exist → `resolveBaseRef()` falls through to `HEAD~1` → `git rev-parse` aborts.

## Fix

Skip the gate when `GITHUB_REF` points at a tag. The changeset was already validated at PR merge time — re-running the gate on the release checkout isn't semantically meaningful.

## Test plan

- [x] Local run with `GITHUB_REF=refs/tags/v0.212.1` short-circuits at the new early-return
- [x] Default PR path unchanged (tag check fires first, non-tag falls through to existing logic)
- [ ] CI 7/7 green
- [ ] Merge → retag v0.212.1 at new HEAD → push tag → Release workflow publishes

## Follow-up

After merge, I'll retag `v0.212.1` at the new `main` HEAD and re-push to trigger `release.yml`. The original tag push at 30afbb2 created a failed workflow run but no dangling state on npm (publish never attempted).