### PR TITLE
fix(release): upgrade npm to 11.5.1+ for Trusted Publishers OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,16 @@ jobs:
           node-version: 22
           registry-url: "https://registry.npmjs.org"
 
+      # Node 22.22 ships with npm 10.9 — Trusted Publishers OIDC flow
+      # requires npm 11.5.1+. Force-install latest npm before anything
+      # touches the registry so `npm publish --provenance` exchanges the
+      # GitHub OIDC token for a short-lived npm token instead of falling
+      # through to the empty NODE_AUTH_TOKEN path and failing ENEEDAUTH.
+      - name: Upgrade npm for Trusted Publishers OIDC
+        run: |
+          npm install -g npm@latest
+          npm --version
+
       - name: Install dependencies
         run: npm ci
 


### PR DESCRIPTION
## Problem

First v0.212.1 release run failed with `npm error code ENEEDAUTH` despite Trusted Publishers being bound on npmjs.com (`olo-dot-io / Uni-CLI / release.yml / npm-publish`).

## Root cause

Node 22.22 ships with npm 10.9. The Trusted Publishers OIDC token-exchange flow landed in npm **11.5.1** (late 2025). With the old npm:

- `setup-node@v6` writes `.npmrc` with `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}`.
- `NODE_AUTH_TOKEN` is empty (no fallback secret, Trusted Publishers intended).
- npm 10 doesn't know to exchange the OIDC token; sees an empty `_authToken`; aborts with ENEEDAUTH.

## Fix

Add `npm install -g npm@latest` between setup-node and `npm ci`. Latest npm (11.x) knows to request the GitHub OIDC token (via the `id-token: write` permission already set at the job level) and exchange it for a short-lived npm token during publish.

## Test plan

- [x] Local dry-run with updated workflow file
- [ ] CI matrix 7/7 green on this PR
- [ ] After merge: retag v0.212.1 at new main HEAD → push tag → Release workflow publishes with OIDC provenance
- [ ] Verify `npm view @zenalexa/unicli version` = 0.212.1 and provenance badge shows on the package page