### PR TITLE
fix(docs): keep markdown links and nav actions usable

### DIFF
--- a/docs/.vitepress/theme/components/AgentDocToolbar.vue
+++ b/docs/.vitepress/theme/components/AgentDocToolbar.vue
@@ -122,7 +122,14 @@ async function copyMarkdown() {
               : "Copy Markdown"
         }}
       </button>
-      <a class="agent-markdown-link" :href="markdownHref">Open .md</a>
+      <a
+        class="agent-markdown-link"
+        :href="markdownHref"
+        target="_self"
+        type="text/markdown"
+      >
+        Open .md
+      </a>
     </div>
   </nav>
 </template>

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -34,6 +34,43 @@
   display: none !important;
 }
 
+.VPNavBarAppearance.appearance,
+.VPNavBarSocialLinks.social-links {
+  display: flex !important;
+  flex-shrink: 0;
+  align-items: center;
+}
+
+.VPNavBarSocialLinks.social-links {
+  margin-right: 0;
+}
+
+@media (max-width: 1279px) {
+  .VPNavBar .menu + .appearance::before,
+  .VPNavBar .translations + .appearance::before,
+  .VPNavBar .appearance + .social-links::before {
+    display: none;
+  }
+}
+
+@media (min-width: 768px) and (max-width: 959px) {
+  .VPNavBarMenu.menu {
+    display: none !important;
+  }
+
+  .VPNavBarHamburger.hamburger {
+    display: flex !important;
+    flex-shrink: 0;
+  }
+}
+
+@media (max-width: 767px) {
+  .VPNavBarSearch.search {
+    flex-grow: 0;
+    padding-left: 0;
+  }
+}
+
 /* Headings: Geist Mono */
 .vp-doc h1,
 .vp-doc h2,


### PR DESCRIPTION
## Summary
- make the agent toolbar Open .md link bypass VitePress client routing so static Markdown opens directly
- keep GitHub and appearance controls visible as first-level nav actions below 1280px
- use the hamburger menu for tablet widths where full nav text would compete with agent-critical actions

## Verification
- pnpm format:check
- pnpm typecheck && pnpm lint
- UNICLI_DOCS_BASE=/Uni-CLI/ npm run docs:build
- Playwright local smoke: Open .md returns 200 text/markdown; nav actions visible with no overlap at 390, 820, 1100, and 1280px
- pre-push verify:clean