### PR TITLE
feat(docs): add pretext typography guardrails

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -265,7 +265,7 @@ $ unicli blender render scene.blend
 [Feature Grid — 3 columns]
 Card: Self-Repair (5-level healing loop diagram)
 Card: Universal (web + desktop + cloud + service)
-Card: Agent-Native (per-call token cost measured in docs/BENCHMARK.md)
+Card: Agent-Native (command budget measured in docs/BENCHMARK.md)
 
 [Coverage Section — dark grid with site logos/names]
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -80,7 +80,8 @@ function escapeMustacheInFence(md: any) {
 
 export default defineConfig({
   title: "Uni-CLI",
-  description: "Agent-native CLI infrastructure for operating real software",
+  description:
+    "The universal interface between AI agents and the world's software",
   base: siteBase,
   srcExclude: ["public/markdown/**/*.md", "demo/README.md"],
   cleanUrls: true,
@@ -105,7 +106,7 @@ export default defineConfig({
       {
         property: "og:description",
         content:
-          "Agent-native CLI infrastructure for discovering, running, and repairing software operations across web, desktop apps, local tools, and external CLIs.",
+          "A shell-native command layer for agents to discover, execute, verify, and repair real workflows across websites, desktop apps, local tools, and external CLIs.",
       },
     ],
     ["meta", { property: "og:url", content: publicSiteUrl }],

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -87,6 +87,29 @@
   font-family: "Geist", system-ui, sans-serif;
 }
 
+.pretext-typography .vp-doc p,
+.pretext-typography .vp-doc li,
+.pretext-typography .VPFeature .details,
+.pretext-typography .site-command-list span {
+  text-wrap: pretty;
+}
+
+.pretext-typography .vp-doc h1,
+.pretext-typography .vp-doc h2,
+.pretext-typography .VPHero .text,
+.pretext-typography .VPHero .tagline,
+.pretext-typography .uni-home-stats h2 {
+  text-wrap: balance;
+}
+
+.pretext-balanced {
+  max-width: min(100%, var(--pretext-balance-width));
+}
+
+.pretext-stabilized {
+  min-height: var(--pretext-height);
+}
+
 /* Code blocks: Geist Mono */
 .vp-doc [class*="language-"] code {
   font-family: "Geist Mono", ui-monospace, monospace;

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -3,6 +3,7 @@ import type { Theme } from "vitepress";
 import Layout from "./components/Layout.vue";
 import SiteCatalog from "./components/SiteCatalog.vue";
 import SiteStats from "./components/SiteStats.vue";
+import { installPretextTypography } from "./pretext-typography";
 import "./custom.css";
 
 export default {
@@ -11,5 +12,6 @@ export default {
   enhanceApp({ app }) {
     app.component("SiteCatalog", SiteCatalog);
     app.component("SiteStats", SiteStats);
+    installPretextTypography();
   },
 } satisfies Theme;

--- a/docs/.vitepress/theme/pretext-typography.ts
+++ b/docs/.vitepress/theme/pretext-typography.ts
@@ -1,0 +1,280 @@
+import { onContentUpdated } from "vitepress";
+import {
+  layout,
+  measureLineStats,
+  prepare,
+  prepareWithSegments,
+  type PreparedText,
+  type PreparedTextWithSegments,
+} from "@chenglou/pretext";
+
+type PreparedEntry = {
+  signature: string;
+  prepared: PreparedText;
+  segmented: PreparedTextWithSegments;
+};
+
+const typographySelector = [
+  ".VPHero .text",
+  ".VPHero .tagline",
+  ".VPFeature .title",
+  ".VPFeature .details",
+  ".uni-home-stats h2",
+  ".uni-home-stats p:not(.uni-eyebrow)",
+  ".uni-surface small",
+  ".vp-doc h1",
+  ".vp-doc h2",
+  ".vp-doc h3",
+  ".vp-doc p",
+  ".vp-doc li",
+  ".site-card h3",
+  ".site-card-top p",
+  ".site-command-list span",
+  ".agent-breadcrumbs [aria-current='page']",
+].join(",");
+
+const balanceSelector = [
+  ".VPHero .text",
+  ".VPHero .tagline",
+  ".uni-home-stats h2",
+  ".vp-doc h1",
+  ".vp-doc h2",
+].join(",");
+
+const stabilizeSelector = [
+  ".site-command-list span",
+  ".VPFeature .details",
+].join(",");
+
+const preparedCache = new WeakMap<Element, PreparedEntry>();
+let mutationObserver: MutationObserver | null = null;
+let resizeObserver: ResizeObserver | null = null;
+let scheduled = false;
+
+function numericPixel(value: string, fallback = 0): number {
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function cssFont(style: CSSStyleDeclaration): string {
+  const fontStyle = style.fontStyle === "normal" ? "" : style.fontStyle;
+  const fontVariant = style.fontVariant === "normal" ? "" : style.fontVariant;
+  return [
+    fontStyle,
+    fontVariant,
+    style.fontWeight,
+    style.fontSize,
+    style.fontFamily,
+  ]
+    .filter(Boolean)
+    .join(" ");
+}
+
+function lineHeight(style: CSSStyleDeclaration): number {
+  if (style.lineHeight === "normal") {
+    return numericPixel(style.fontSize, 16) * 1.45;
+  }
+
+  return numericPixel(
+    style.lineHeight,
+    numericPixel(style.fontSize, 16) * 1.45,
+  );
+}
+
+function whiteSpaceMode(style: CSSStyleDeclaration): "normal" | "pre-wrap" {
+  return style.whiteSpace === "pre-wrap" || style.whiteSpace === "break-spaces"
+    ? "pre-wrap"
+    : "normal";
+}
+
+function textForMeasurement(element: Element): string {
+  return (element.textContent ?? "").replace(/\s+/g, " ").trim();
+}
+
+function preparedFor(
+  element: Element,
+  text: string,
+  font: string,
+  style: CSSStyleDeclaration,
+): PreparedEntry {
+  const letterSpacing = numericPixel(style.letterSpacing, 0);
+  const wordBreak = style.wordBreak === "keep-all" ? "keep-all" : "normal";
+  const whiteSpace = whiteSpaceMode(style);
+  const signature = JSON.stringify({
+    text,
+    font,
+    letterSpacing,
+    whiteSpace,
+    wordBreak,
+  });
+  const cached = preparedCache.get(element);
+
+  if (cached?.signature === signature) {
+    return cached;
+  }
+
+  const options = { letterSpacing, whiteSpace, wordBreak } as const;
+  const entry = {
+    signature,
+    prepared: prepare(text, font, options),
+    segmented: prepareWithSegments(text, font, options),
+  };
+  preparedCache.set(element, entry);
+  return entry;
+}
+
+function balancedWidth(
+  prepared: PreparedTextWithSegments,
+  maxWidth: number,
+): number | null {
+  if (maxWidth < 320) {
+    return null;
+  }
+
+  const base = measureLineStats(prepared, maxWidth);
+  if (base.lineCount < 2) {
+    return null;
+  }
+
+  const minWidth = Math.max(220, Math.floor(maxWidth * 0.58));
+  let bestWidth = maxWidth;
+  let bestScore = Number.POSITIVE_INFINITY;
+
+  for (let width = maxWidth; width >= minWidth; width -= 8) {
+    const stats = measureLineStats(prepared, width);
+    if (stats.lineCount !== base.lineCount) {
+      continue;
+    }
+
+    const raggedEdge = Math.max(0, width - stats.maxLineWidth);
+    const opticalWidth = Math.abs(width - maxWidth * 0.88);
+    const score = raggedEdge + opticalWidth * 0.18;
+    if (score < bestScore) {
+      bestScore = score;
+      bestWidth = width;
+    }
+  }
+
+  return bestWidth < maxWidth - 12 ? bestWidth : null;
+}
+
+function measureElement(element: Element): void {
+  if (!(element instanceof HTMLElement)) {
+    return;
+  }
+
+  const text = textForMeasurement(element);
+  if (!text) {
+    return;
+  }
+
+  const rect = element.getBoundingClientRect();
+  if (rect.width < 12 || rect.height === 0) {
+    return;
+  }
+
+  const style = getComputedStyle(element);
+  const font = cssFont(style);
+  const entry = preparedFor(element, text, font, style);
+  const maxWidth = Math.floor(rect.width);
+  const lineHeightPx = lineHeight(style);
+  const result = layout(entry.prepared, maxWidth, lineHeightPx);
+
+  element.classList.add("pretext-measured");
+  element.style.setProperty("--pretext-lines", String(result.lineCount));
+  element.style.setProperty(
+    "--pretext-height",
+    `${Math.ceil(result.height)}px`,
+  );
+  element.dataset.pretextLines = String(result.lineCount);
+
+  if (element.matches(balanceSelector)) {
+    const width = balancedWidth(entry.segmented, maxWidth);
+    if (width) {
+      element.classList.add("pretext-balanced");
+      element.style.setProperty("--pretext-balance-width", `${width}px`);
+    } else {
+      element.classList.remove("pretext-balanced");
+      element.style.removeProperty("--pretext-balance-width");
+    }
+  }
+
+  if (element.matches(stabilizeSelector) && result.lineCount > 1) {
+    element.classList.add("pretext-stabilized");
+  } else {
+    element.classList.remove("pretext-stabilized");
+  }
+}
+
+function clearPretextState(element: Element): void {
+  element.classList.remove(
+    "pretext-measured",
+    "pretext-balanced",
+    "pretext-stabilized",
+  );
+
+  if (element instanceof HTMLElement) {
+    element.style.removeProperty("--pretext-lines");
+    element.style.removeProperty("--pretext-height");
+    element.style.removeProperty("--pretext-balance-width");
+    delete element.dataset.pretextLines;
+  }
+}
+
+function runPretextPass(): void {
+  scheduled = false;
+  document.documentElement.classList.add("pretext-typography");
+
+  for (const element of document.querySelectorAll(typographySelector)) {
+    try {
+      measureElement(element);
+    } catch {
+      clearPretextState(element);
+    }
+  }
+}
+
+function schedulePretextPass(): void {
+  if (scheduled) {
+    return;
+  }
+
+  scheduled = true;
+  window.requestAnimationFrame(runPretextPass);
+}
+
+function canMeasureText(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    "Segmenter" in Intl &&
+    (typeof OffscreenCanvas !== "undefined" ||
+      typeof document.createElement("canvas").getContext === "function")
+  );
+}
+
+export function installPretextTypography(): void {
+  if (!canMeasureText()) {
+    return;
+  }
+
+  onContentUpdated(schedulePretextPass);
+  window.addEventListener("resize", schedulePretextPass, { passive: true });
+
+  mutationObserver?.disconnect();
+  mutationObserver = new MutationObserver(schedulePretextPass);
+  mutationObserver.observe(document.body, {
+    childList: true,
+    subtree: true,
+    characterData: true,
+  });
+
+  resizeObserver?.disconnect();
+  resizeObserver = new ResizeObserver(schedulePretextPass);
+  resizeObserver.observe(document.documentElement);
+
+  if (document.fonts) {
+    void document.fonts.ready.then(schedulePretextPass);
+  }
+
+  schedulePretextPass();
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,8 +3,8 @@ layout: home
 
 hero:
   name: "Uni-CLI"
-  text: "The native command surface for agents."
-  tagline: "Search by intent, run typed commands, get structured envelopes, and repair broken tools without leaving the shell."
+  text: "The universal interface between AI agents and the world's software."
+  tagline: "A shell-native command layer for real operations: discover by intent, execute typed adapters, return structured AgentEnvelopes, and repair broken automation in place."
   image:
     src: /mascot-otter.png
     alt: Uni-CLI otter mascot holding a terminal tablet

--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -24,9 +24,9 @@ Markdown: https://olo-dot-io.github.io/Uni-CLI/markdown/index.md
 - Markdown: https://olo-dot-io.github.io/Uni-CLI/markdown/index.md
 - Section: Start
 
-## The native command surface for agents.
+## The universal interface between AI agents and the world's software.
 
-Search by intent, run typed commands, get structured envelopes, and repair broken tools without leaving the shell.
+A shell-native command layer for real operations: discover by intent, execute typed adapters, return structured AgentEnvelopes, and repair broken automation in place.
 
 ## Primary Actions
 

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -8,7 +8,7 @@ Uni-CLI is the CLI-native command surface for AI agents to discover, run, and re
 - Commands: 1304
 - Adapters: 987 (907 YAML + 80 TypeScript)
 - Pipeline steps: 59
-- Tests: 7311
+- Tests: 7317
 
 ## Agent Contract
 

--- a/docs/public/markdown/index.md
+++ b/docs/public/markdown/index.md
@@ -6,9 +6,9 @@
 - Markdown: https://olo-dot-io.github.io/Uni-CLI/markdown/index.md
 - Section: Start
 
-## The native command surface for agents.
+## The universal interface between AI agents and the world's software.
 
-Search by intent, run typed commands, get structured envelopes, and repair broken tools without leaving the shell.
+A shell-native command layer for real operations: discover by intent, execute typed adapters, return structured AgentEnvelopes, and repair broken automation in place.
 
 ## Primary Actions
 

--- a/docs/public/site.webmanifest
+++ b/docs/public/site.webmanifest
@@ -1,7 +1,7 @@
 {
   "name": "Uni-CLI",
   "short_name": "Uni-CLI",
-  "description": "Agent-native CLI infrastructure for operating real software.",
+  "description": "The universal interface between AI agents and the world's software.",
   "start_url": ".",
   "display": "standalone",
   "background_color": "#11100f",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
       "devDependencies": {
         "@ai-sdk/openai-compatible": "^2.0.41",
         "@changesets/cli": "^2.30.0",
+        "@chenglou/pretext": "^0.0.6",
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^25.6.0",
         "@types/shell-quote": "^1.7.5",
@@ -621,6 +622,13 @@
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
+    },
+    "node_modules/@chenglou/pretext": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@chenglou/pretext/-/pretext-0.0.6.tgz",
+      "integrity": "sha512-U10s4tFeyu3oVHfXuNWwZSKqHXefhaigpcBkGj60qQFRJ+yUoQ+ez3cGJelP7BWDAB58HCgjcTSmOcg+77afBQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@colors/colors": {
       "version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -152,7 +152,8 @@
     "verify:clean": "npm run clean && npm run verify",
     "docs:prepare": "tsx scripts/generate-docs-agent-assets.ts",
     "docs:dev": "npm run docs:prepare && vitepress dev docs",
-    "docs:build": "npm run docs:prepare && node -e \"require('node:fs').rmSync('docs/.vitepress/dist',{recursive:true,force:true})\" && vitepress build docs",
+    "docs:check-public": "tsx scripts/check-public-docs.ts",
+    "docs:build": "npm run docs:prepare && node -e \"require('node:fs').rmSync('docs/.vitepress/dist',{recursive:true,force:true})\" && vitepress build docs && npm run docs:check-public",
     "docs:preview": "vitepress preview docs",
     "doctor": "tsx src/doctor.ts",
     "mcp": "tsx src/mcp/server.ts",
@@ -209,6 +210,7 @@
   "devDependencies": {
     "@ai-sdk/openai-compatible": "^2.0.41",
     "@changesets/cli": "^2.30.0",
+    "@chenglou/pretext": "^0.0.6",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^25.6.0",
     "@types/shell-quote": "^1.7.5",

--- a/scripts/check-public-docs.ts
+++ b/scripts/check-public-docs.ts
@@ -1,0 +1,126 @@
+#!/usr/bin/env tsx
+/**
+ * Guardrails for the public docs surface.
+ *
+ * The public site is English-only today and must not regress to stale internal
+ * phrasing. This scans generated agent assets plus the VitePress output that
+ * GitHub Pages deploys.
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { extname, join, relative, resolve } from "node:path";
+
+const publicTextRoots = [
+  "docs/site-index.json",
+  "docs/public",
+  "docs/.vitepress/dist",
+];
+const textExtensions = new Set([
+  ".html",
+  ".json",
+  ".md",
+  ".txt",
+  ".webmanifest",
+]);
+const ignoredPathFragments = [
+  "/docs/.vitepress/dist/assets/style",
+  "/docs/.vitepress/dist/assets/inter-",
+  "/docs/.vitepress/dist/vp-icons.css",
+];
+const cjkPattern =
+  /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}\u3000-\u303f\uff00-\uffef]/u;
+const bannedPatterns = [/\bper-call\b/iu];
+
+type Finding = {
+  file: string;
+  line: number;
+  reason: string;
+  text: string;
+};
+
+function toPosix(path: string): string {
+  return path.replace(/\\/g, "/");
+}
+
+function shouldScan(filePath: string): boolean {
+  const normalized = `/${toPosix(relative(process.cwd(), filePath))}`;
+
+  if (ignoredPathFragments.some((fragment) => normalized.includes(fragment))) {
+    return false;
+  }
+
+  return textExtensions.has(extname(filePath));
+}
+
+function collectFiles(target: string, files: string[] = []): string[] {
+  const fullPath = resolve(target);
+  if (!existsSync(fullPath)) {
+    return files;
+  }
+
+  const stat = statSync(fullPath);
+  if (stat.isFile()) {
+    if (shouldScan(fullPath)) {
+      files.push(fullPath);
+    }
+    return files;
+  }
+
+  for (const entry of readdirSync(fullPath)) {
+    collectFiles(join(fullPath, entry), files);
+  }
+
+  return files;
+}
+
+function scanFile(filePath: string): Finding[] {
+  const text = readFileSync(filePath, "utf-8");
+  const lines = text.split(/\r?\n/);
+  const findings: Finding[] = [];
+
+  lines.forEach((lineText, index) => {
+    if (cjkPattern.test(lineText)) {
+      findings.push({
+        file: toPosix(relative(process.cwd(), filePath)),
+        line: index + 1,
+        reason: "CJK text is not allowed on the public English docs surface",
+        text: lineText.trim(),
+      });
+    }
+
+    for (const pattern of bannedPatterns) {
+      if (pattern.test(lineText)) {
+        findings.push({
+          file: toPosix(relative(process.cwd(), filePath)),
+          line: index + 1,
+          reason: `Banned stale public phrase: ${pattern.source}`,
+          text: lineText.trim(),
+        });
+      }
+    }
+  });
+
+  return findings;
+}
+
+function main(): void {
+  const files = publicTextRoots.flatMap((target) => collectFiles(target));
+  const findings = files.flatMap(scanFile);
+
+  if (findings.length > 0) {
+    process.stderr.write("Public docs check failed:\n");
+    for (const finding of findings.slice(0, 50)) {
+      process.stderr.write(
+        `- ${finding.file}:${finding.line} ${finding.reason}\n  ${finding.text}\n`,
+      );
+    }
+    if (findings.length > 50) {
+      process.stderr.write(`...and ${findings.length - 50} more findings.\n`);
+    }
+    process.exit(1);
+  }
+
+  process.stdout.write(`public docs check passed: ${files.length} files\n`);
+}
+
+main();


### PR DESCRIPTION
## Summary
- integrate @chenglou/pretext into the VitePress theme to measure and stabilize public docs typography
- restore the site slogan/meta/manifest copy to the project direction and remove stale per-call framing
- add a public docs gate that fails builds on CJK text or stale per-call wording in generated public assets

## Verification
- npm run verify
- UNICLI_DOCS_BASE=/Uni-CLI/ npm run docs:build
- local VitePress preview + headless Chrome checks for /reference/sites and / across 320/390/900/1280px