### PR TITLE
feat: trace runtime permission denies

### DIFF
--- a/.changeset/runtime-policy-trace.md
+++ b/.changeset/runtime-policy-trace.md
@@ -1,0 +1,5 @@
+---
+"@zenalexa/unicli": minor
+---
+
+Trace runtime permission denies in recorded runs, compare the blocked rule and resource bucket, and keep raw runtime resources inside internal trace payloads.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 </p>
 
 <p align="center">
-  <sub><!-- STATS:site_count -->235<!-- /STATS --> sites · <!-- STATS:command_count -->1448<!-- /STATS --> commands · <!-- STATS:pipeline_step_count -->59<!-- /STATS --> pipeline steps · <!-- STATS:test_count -->7557<!-- /STATS --> tests</sub>
+  <sub><!-- STATS:site_count -->235<!-- /STATS --> sites · <!-- STATS:command_count -->1448<!-- /STATS --> commands · <!-- STATS:pipeline_step_count -->59<!-- /STATS --> pipeline steps · <!-- STATS:test_count -->7560<!-- /STATS --> tests</sub>
 </p>
 
 <p align="center">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -28,7 +28,7 @@
 </p>
 
 <p align="center">
-  <sub><!-- STATS:site_count -->235<!-- /STATS --> 个站点 · <!-- STATS:command_count -->1448<!-- /STATS --> 条命令 · <!-- STATS:pipeline_step_count -->59<!-- /STATS --> 个 pipeline step · <!-- STATS:test_count -->7557<!-- /STATS --> 个测试</sub>
+  <sub><!-- STATS:site_count -->235<!-- /STATS --> 个站点 · <!-- STATS:command_count -->1448<!-- /STATS --> 条命令 · <!-- STATS:pipeline_step_count -->59<!-- /STATS --> 个 pipeline step · <!-- STATS:test_count -->7560<!-- /STATS --> 个测试</sub>
 </p>
 
 <p align="center">

--- a/contributing/COPY.md
+++ b/contributing/COPY.md
@@ -2,7 +2,7 @@
 
 > Current version: v0.217.0 — Apollo · Lovell.
 >
-> Current scale: <!-- STATS:site_count -->235<!-- /STATS --> sites, <!-- STATS:command_count -->1448<!-- /STATS --> commands, <!-- STATS:adapter_count_total -->1039<!-- /STATS --> adapters (<!-- STATS:adapter_count_yaml -->917<!-- /STATS --> YAML + <!-- STATS:adapter_count_ts -->122<!-- /STATS --> TS), <!-- STATS:test_count -->7557<!-- /STATS --> tests.
+> Current scale: <!-- STATS:site_count -->235<!-- /STATS --> sites, <!-- STATS:command_count -->1448<!-- /STATS --> commands, <!-- STATS:adapter_count_total -->1039<!-- /STATS --> adapters (<!-- STATS:adapter_count_yaml -->917<!-- /STATS --> YAML + <!-- STATS:adapter_count_ts -->122<!-- /STATS --> TS), <!-- STATS:test_count -->7560<!-- /STATS --> tests.
 
 This file keeps docs and user-facing copy consistent. Public pages should expose
 install, command, output, and repair facts with the fewest words needed.

--- a/src/engine/kernel/execute.ts
+++ b/src/engine/kernel/execute.ts
@@ -11,7 +11,7 @@
  * transport; they do not rebuild envelopes.
  */
 
-import { runPipeline } from "../executor.js";
+import { PipelineError, runPipeline } from "../executor.js";
 import { hardenArgs, InputHardeningError } from "../harden.js";
 import {
   defaultSuccessNextActions,
@@ -37,7 +37,11 @@ import { evaluateOperationPolicyWithApprovals } from "../permission-runtime.js";
 import { PermissionRulesConfigError } from "../permission-rules.js";
 
 import { getCompiled } from "./compile.js";
-import type { Invocation, InvocationResult } from "./types.js";
+import type {
+  Invocation,
+  InvocationDiagnostic,
+  InvocationResult,
+} from "./types.js";
 import { newULID } from "./ulid.js";
 
 /**
@@ -53,6 +57,61 @@ export class KernelLookupError extends Error {
     );
     this.name = "KernelLookupError";
   }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function resourcesFromPermissionConfig(
+  config: unknown,
+): Record<string, string[]> | undefined {
+  if (!isRecord(config) || !isRecord(config.resources)) return undefined;
+
+  const resources: Record<string, string[]> = {};
+  for (const [bucket, raw] of Object.entries(config.resources)) {
+    if (!Array.isArray(raw)) continue;
+    const values = raw.filter((value): value is string => {
+      return typeof value === "string";
+    });
+    if (values.length > 0) resources[bucket] = values;
+  }
+
+  return Object.keys(resources).length > 0 ? resources : undefined;
+}
+
+function runtimePermissionDeniedDiagnostic(
+  err: unknown,
+): InvocationDiagnostic | undefined {
+  if (
+    !(err instanceof PipelineError) ||
+    err.detail.errorType !== "permission_denied"
+  ) {
+    return undefined;
+  }
+
+  const config = err.detail.config;
+  const resources = resourcesFromPermissionConfig(config);
+  const ruleId =
+    isRecord(config) && typeof config.rule_id === "string"
+      ? config.rule_id
+      : undefined;
+
+  return {
+    kind: "runtime_permission_denied",
+    code: "permission_denied",
+    action: err.detail.action,
+    step: err.detail.step,
+    retryable: err.detail.retryable ?? false,
+    ...(ruleId ? { rule_id: ruleId } : {}),
+    resource_buckets: resources ? Object.keys(resources).sort() : [],
+    ...(resources ? { resources } : {}),
+  };
+}
+
+function diagnosticsForError(err: unknown): InvocationDiagnostic[] | undefined {
+  const diagnostic = runtimePermissionDeniedDiagnostic(err);
+  return diagnostic ? [diagnostic] : undefined;
 }
 
 /**
@@ -436,6 +495,7 @@ export async function execute(inv: Invocation): Promise<InvocationResult> {
       message: err instanceof Error ? err.message : String(err),
       ...fields,
     };
+    const diagnostics = diagnosticsForError(err);
     const durationMs = Date.now() - startedAt;
     return {
       results: [],
@@ -455,6 +515,7 @@ export async function execute(inv: Invocation): Promise<InvocationResult> {
       exitCode: mapErrorToExitCode(err),
       warnings,
       error: agentErr,
+      ...(diagnostics ? { diagnostics } : {}),
     };
   }
 

--- a/src/engine/kernel/types.ts
+++ b/src/engine/kernel/types.ts
@@ -56,4 +56,18 @@ export interface InvocationResult {
   exitCode: number;
   warnings: string[];
   error?: AgentError;
+  diagnostics?: InvocationDiagnostic[];
+}
+
+export type InvocationDiagnostic = RuntimePermissionDeniedDiagnostic;
+
+export interface RuntimePermissionDeniedDiagnostic {
+  kind: "runtime_permission_denied";
+  code: "permission_denied";
+  action: string;
+  step: number;
+  retryable: boolean;
+  rule_id?: string;
+  resource_buckets: string[];
+  resources?: Record<string, string[]>;
 }

--- a/src/engine/session/compare.ts
+++ b/src/engine/session/compare.ts
@@ -115,7 +115,8 @@ function scanComparableEvents(events: RunEvent[]): ComparableEventScan {
       scan.terminal &&
       scan.toolTerminal &&
       scan.resultEnvelope &&
-      scan.runtimePermissionDenied
+      (scan.runtimePermissionDenied ||
+        errorCodeFromEvent(scan.toolTerminal) !== "permission_denied")
     ) {
       break;
     }

--- a/src/engine/session/compare.ts
+++ b/src/engine/session/compare.ts
@@ -18,6 +18,14 @@ export interface RunComparableResult {
   error_code?: string;
   envelope_command?: string;
   has_error?: boolean;
+  runtime_permission_denied?: RunComparableRuntimePermissionDenied;
+}
+
+export interface RunComparableRuntimePermissionDenied {
+  action?: string;
+  step?: number;
+  rule_id?: string;
+  resource_buckets?: string[];
 }
 
 export interface RunComparableEvidence {
@@ -70,6 +78,7 @@ interface ComparableEventScan {
   terminal?: RunEvent;
   toolTerminal?: RunEvent;
   resultEnvelope?: RunEvent;
+  runtimePermissionDenied?: RunEvent;
 }
 
 function scanComparableEvents(events: RunEvent[]): ComparableEventScan {
@@ -96,7 +105,20 @@ function scanComparableEvents(events: RunEvent[]): ComparableEventScan {
     ) {
       scan.resultEnvelope = event;
     }
-    if (scan.terminal && scan.toolTerminal && scan.resultEnvelope) break;
+    if (
+      !scan.runtimePermissionDenied &&
+      event.name === "permission.runtime_denied"
+    ) {
+      scan.runtimePermissionDenied = event;
+    }
+    if (
+      scan.terminal &&
+      scan.toolTerminal &&
+      scan.resultEnvelope &&
+      scan.runtimePermissionDenied
+    ) {
+      break;
+    }
   }
   return scan;
 }
@@ -147,6 +169,35 @@ function errorCodeFromEvent(event?: RunEvent): string | undefined {
   return undefined;
 }
 
+function stringArrayField(
+  field: string,
+  event?: RunEvent,
+): string[] | undefined {
+  const value = event?.data?.[field];
+  if (!Array.isArray(value)) return undefined;
+  const values = value.filter((entry): entry is string => {
+    return typeof entry === "string";
+  });
+  return values.length > 0 ? values : undefined;
+}
+
+function runtimePermissionDeniedFromEvent(
+  event?: RunEvent,
+): RunComparableRuntimePermissionDenied | undefined {
+  if (!event) return undefined;
+  const action = stringField("action", event);
+  const step = numberField("step", event);
+  const ruleId = stringField("rule_id", event);
+  const resourceBuckets = stringArrayField("resource_buckets", event);
+
+  return {
+    ...(action ? { action } : {}),
+    ...(step !== undefined ? { step } : {}),
+    ...(ruleId ? { rule_id: ruleId } : {}),
+    ...(resourceBuckets ? { resource_buckets: resourceBuckets } : {}),
+  };
+}
+
 function evidenceSummary(events: RunEvent[]): RunComparableEvidence {
   const byType: Record<string, number> = {};
   for (const event of events) {
@@ -169,8 +220,9 @@ export function summarizeComparableRun(
 ): RunComparableSummary {
   const summary = summarizeRunEvents(events, { runId });
   const metadata = metadataFromEvents(events);
-  const { terminal, toolTerminal, resultEnvelope } =
-    scanComparableEvents(events);
+  const scan = scanComparableEvents(events);
+  const { terminal, toolTerminal, resultEnvelope, runtimePermissionDenied } =
+    scan;
   const exitCode = numberField(
     "exit_code",
     terminal,
@@ -187,6 +239,9 @@ export function summarizeComparableRun(
   const hasError = booleanField("has_error", resultEnvelope);
   const errorCode =
     errorCodeFromEvent(terminal) ?? errorCodeFromEvent(toolTerminal);
+  const runtimePermissionDeniedResult = runtimePermissionDeniedFromEvent(
+    runtimePermissionDenied,
+  );
 
   return {
     run_id: runId,
@@ -220,9 +275,18 @@ export function summarizeComparableRun(
       ...(errorCode ? { error_code: errorCode } : {}),
       ...(envelopeCommand ? { envelope_command: envelopeCommand } : {}),
       ...(hasError !== undefined ? { has_error: hasError } : {}),
+      ...(runtimePermissionDeniedResult
+        ? { runtime_permission_denied: runtimePermissionDeniedResult }
+        : {}),
     },
     evidence: evidenceSummary(events),
   };
+}
+
+function joinedBuckets(
+  runtimePermissionDenied?: RunComparableRuntimePermissionDenied,
+): string | undefined {
+  return runtimePermissionDenied?.resource_buckets?.slice().sort().join(",");
 }
 
 function compareScalar(
@@ -309,6 +373,34 @@ export function compareRunEvents(
       left.result.has_error,
       right.result.has_error,
       "behavior",
+    ),
+    compareScalar(
+      "runtime_permission_rule",
+      left.result.runtime_permission_denied?.rule_id,
+      right.result.runtime_permission_denied?.rule_id,
+      "behavior",
+      { missingMeansMatch: true },
+    ),
+    compareScalar(
+      "runtime_permission_action",
+      left.result.runtime_permission_denied?.action,
+      right.result.runtime_permission_denied?.action,
+      "behavior",
+      { missingMeansMatch: true },
+    ),
+    compareScalar(
+      "runtime_permission_step",
+      left.result.runtime_permission_denied?.step,
+      right.result.runtime_permission_denied?.step,
+      "behavior",
+      { missingMeansMatch: true },
+    ),
+    compareScalar(
+      "runtime_permission_resource_buckets",
+      joinedBuckets(left.result.runtime_permission_denied),
+      joinedBuckets(right.result.runtime_permission_denied),
+      "behavior",
+      { missingMeansMatch: true },
     ),
     compareScalar(
       "permission_profile",

--- a/src/engine/session/events.ts
+++ b/src/engine/session/events.ts
@@ -87,6 +87,18 @@ export function createPermissionEvaluatedEvent(
   return createEvent("permission.evaluated", metadata, sequence, { data });
 }
 
+export function createRuntimePermissionDeniedEvent(
+  metadata: RunTraceMetadata,
+  sequence: RunEventSequence,
+  data: Record<string, unknown>,
+  internal?: unknown,
+): RunEvent {
+  return createEvent("permission.runtime_denied", metadata, sequence, {
+    data,
+    ...(internal !== undefined ? { internal } : {}),
+  });
+}
+
 export function createEvidenceCapturedEvent(
   metadata: RunTraceMetadata,
   sequence: RunEventSequence,

--- a/src/engine/session/run-loop.ts
+++ b/src/engine/session/run-loop.ts
@@ -17,6 +17,7 @@ import {
 import {
   createPermissionEvaluatedEvent,
   createEvidenceCapturedEvent,
+  createRuntimePermissionDeniedEvent,
   createRunCompletedEvent,
   createRunEventSequence,
   createRunFailedEvent,
@@ -213,6 +214,32 @@ function evidenceData(
   };
 }
 
+function runtimePermissionDeniedEvent(
+  result: InvocationResult,
+  metadata: RunTraceMetadata,
+  sequence: ReturnType<typeof createRunEventSequence>,
+): RunEvent | undefined {
+  const diagnostic = result.diagnostics?.find(
+    (entry) => entry.kind === "runtime_permission_denied",
+  );
+  if (!diagnostic) return undefined;
+
+  return createRuntimePermissionDeniedEvent(
+    metadata,
+    sequence,
+    {
+      code: diagnostic.code,
+      adapter_path: metadata.adapter_path,
+      action: diagnostic.action,
+      step: diagnostic.step,
+      ...(diagnostic.rule_id ? { rule_id: diagnostic.rule_id } : {}),
+      resource_buckets: diagnostic.resource_buckets,
+      retryable: diagnostic.retryable,
+    },
+    diagnostic.resources ? { resources: diagnostic.resources } : undefined,
+  );
+}
+
 export async function executeWithRunRecording(
   inv: Invocation,
   options: RunRecordingOptions = {},
@@ -242,6 +269,11 @@ export async function executeWithRunRecording(
   );
 
   const result = await execute(inv);
+  const runtimeDenied = runtimePermissionDeniedEvent(
+    result,
+    metadata,
+    sequence,
+  );
   const terminalEvents =
     result.error === undefined
       ? [
@@ -254,6 +286,7 @@ export async function executeWithRunRecording(
           createRunCompletedEvent(metadata, sequence, successData(result)),
         ]
       : [
+          ...(runtimeDenied ? [runtimeDenied] : []),
           createToolCallFailedEvent(
             metadata,
             sequence,

--- a/src/engine/session/types.ts
+++ b/src/engine/session/types.ts
@@ -9,6 +9,7 @@ export type RunEventName =
   | "run.started"
   | "tool.call.started"
   | "permission.evaluated"
+  | "permission.runtime_denied"
   | "evidence.captured"
   | "tool.call.completed"
   | "tool.call.failed"

--- a/stats.json
+++ b/stats.json
@@ -4,7 +4,7 @@
   "adapter_count_total": 1039,
   "site_count": 235,
   "command_count": 1448,
-  "test_count": 7557,
+  "test_count": 7560,
   "pipeline_step_count": 59,
   "transport_count": 3,
   "app_transport_count": 7,

--- a/tests/unit/session-compare.test.ts
+++ b/tests/unit/session-compare.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createEvidenceCapturedEvent,
+  createPermissionEvaluatedEvent,
+  createRunEventSequence,
+  createRunFailedEvent,
+  createRunStartedEvent,
+  createRuntimePermissionDeniedEvent,
+  createToolCallFailedEvent,
+  createToolCallStartedEvent,
+  type RunTraceMetadata,
+} from "../../src/engine/session/events.js";
+import { compareRunEvents } from "../../src/engine/session/compare.js";
+import type { RunEvent, RunId } from "../../src/engine/session/types.js";
+
+function metadataFor(runId: RunId): RunTraceMetadata {
+  return {
+    run_id: runId,
+    trace_id: `01HTRACE${runId.replaceAll("-", "").toUpperCase()}0000`,
+    command: "session-fixture.runtime-deny",
+    site: "session-fixture",
+    cmd: "runtime-deny",
+    adapter_path: "src/adapters/session-fixture/runtime-deny.yaml",
+    permission_profile: "open",
+    transport_surface: "cli",
+    target_surface: "web",
+    args_hash: "sha256:runtime-deny",
+    pipeline_steps: 1,
+  };
+}
+
+function deniedTrace(
+  runId: RunId,
+  ruleId: string,
+  resourceBuckets: string[],
+): RunEvent[] {
+  const metadata = metadataFor(runId);
+  const sequence = createRunEventSequence();
+  const error = {
+    code: "permission_denied",
+    message: `permission rule "${ruleId}" denies runtime resource`,
+    adapter_path: metadata.adapter_path,
+    step: 0,
+    suggestion: `Edit or remove permission rule "${ruleId}".`,
+    retryable: false,
+  };
+  const resultData = {
+    exit_code: 77,
+    result_count: 0,
+    duration_ms: 7,
+    error,
+    envelope: { command: metadata.command, error },
+  };
+
+  return [
+    createRunStartedEvent(metadata, sequence),
+    createToolCallStartedEvent(metadata, sequence),
+    createPermissionEvaluatedEvent(metadata, sequence, {
+      profile: "open",
+      effect: "read",
+      risk: "low",
+      enforcement: "allow",
+    }),
+    createRuntimePermissionDeniedEvent(metadata, sequence, {
+      code: "permission_denied",
+      adapter_path: metadata.adapter_path,
+      action: "fetch_text",
+      step: 0,
+      rule_id: ruleId,
+      resource_buckets: resourceBuckets,
+      retryable: false,
+    }),
+    createToolCallFailedEvent(metadata, sequence, resultData),
+    createEvidenceCapturedEvent(metadata, sequence, {
+      evidence_type: "result-envelope",
+      data: {
+        outcome: "failure",
+        exit_code: 77,
+        result_count: 0,
+        duration_ms: 7,
+        adapter_path: metadata.adapter_path,
+        envelope_command: metadata.command,
+        has_error: true,
+      },
+    }),
+    createRunFailedEvent(metadata, sequence, resultData),
+  ];
+}
+
+describe("run trace comparison", () => {
+  it("compares runtime permission deny decisions without raw resources", () => {
+    const comparison = compareRunEvents(
+      deniedTrace("run-left", "deny-old-domain", ["domains"]),
+      deniedTrace("run-right", "deny-new-path", ["paths"]),
+      { leftRunId: "run-left", rightRunId: "run-right" },
+    );
+
+    expect(comparison.status).toBe("diverged");
+    expect(comparison.left.result).toMatchObject({
+      error_code: "permission_denied",
+      runtime_permission_denied: {
+        action: "fetch_text",
+        step: 0,
+        rule_id: "deny-old-domain",
+        resource_buckets: ["domains"],
+      },
+    });
+    expect(comparison.right.result).toMatchObject({
+      runtime_permission_denied: {
+        rule_id: "deny-new-path",
+        resource_buckets: ["paths"],
+      },
+    });
+    expect(comparison.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "runtime_permission_rule",
+          impact: "behavior",
+          status: "diverged",
+        }),
+        expect.objectContaining({
+          name: "runtime_permission_resource_buckets",
+          impact: "behavior",
+          status: "diverged",
+        }),
+      ]),
+    );
+    expect(JSON.stringify(comparison)).not.toContain("blocked.example");
+  });
+});

--- a/tests/unit/session-compare.test.ts
+++ b/tests/unit/session-compare.test.ts
@@ -62,15 +62,24 @@ function deniedTrace(
       risk: "low",
       enforcement: "allow",
     }),
-    createRuntimePermissionDeniedEvent(metadata, sequence, {
-      code: "permission_denied",
-      adapter_path: metadata.adapter_path,
-      action: "fetch_text",
-      step: 0,
-      rule_id: ruleId,
-      resource_buckets: resourceBuckets,
-      retryable: false,
-    }),
+    createRuntimePermissionDeniedEvent(
+      metadata,
+      sequence,
+      {
+        code: "permission_denied",
+        adapter_path: metadata.adapter_path,
+        action: "fetch_text",
+        step: 0,
+        rule_id: ruleId,
+        resource_buckets: resourceBuckets,
+        retryable: false,
+      },
+      {
+        resources: {
+          domains: ["blocked.example"],
+        },
+      },
+    ),
     createToolCallFailedEvent(metadata, sequence, resultData),
     createEvidenceCapturedEvent(metadata, sequence, {
       evidence_type: "result-envelope",

--- a/tests/unit/session-events.test.ts
+++ b/tests/unit/session-events.test.ts
@@ -5,6 +5,7 @@ import {
   createPermissionEvaluatedEvent,
   createRunEventSequence,
   createRunStartedEvent,
+  createRuntimePermissionDeniedEvent,
   createToolCallStartedEvent,
   projectRunEventForPublicSurface,
   type RunTraceMetadata,
@@ -81,5 +82,41 @@ describe("session event builders", () => {
     });
     expect(projected).not.toHaveProperty("internal");
     expect(projected).not.toHaveProperty("secret");
+  });
+
+  it("builds runtime permission deny events without exposing raw resources publicly", () => {
+    const sequence = createRunEventSequence();
+    const event = createRuntimePermissionDeniedEvent(
+      metadata,
+      sequence,
+      {
+        code: "permission_denied",
+        adapter_path: metadata.adapter_path,
+        action: "fetch_text",
+        step: 0,
+        rule_id: "deny-runtime-domain",
+        resource_buckets: ["domains"],
+        retryable: false,
+      },
+      {
+        resources: {
+          domains: ["blocked.example"],
+        },
+      },
+    );
+
+    const projected = projectRunEventForPublicSurface(event);
+
+    expect(projected).toMatchObject({
+      name: "permission.runtime_denied",
+      data: {
+        code: "permission_denied",
+        rule_id: "deny-runtime-domain",
+        resource_buckets: ["domains"],
+      },
+    });
+    expect(projected).not.toHaveProperty("internal");
+    expect(projected).not.toHaveProperty("secret");
+    expect(JSON.stringify(projected)).not.toContain("blocked.example");
   });
 });

--- a/tests/unit/session-run-loop.test.ts
+++ b/tests/unit/session-run-loop.test.ts
@@ -36,6 +36,18 @@ const fixture: AdapterManifest = {
         throw new Error("fixture failure");
       },
     },
+    "runtime-deny": {
+      name: "runtime-deny",
+      description: "Fetch denied runtime data",
+      adapterArgs: [],
+      pipeline: [
+        {
+          fetch_text: {
+            url: "https://blocked.example/secret?token=hidden",
+          },
+        },
+      ],
+    },
   },
 };
 
@@ -144,6 +156,73 @@ describe("recorded run wrapper", () => {
         adapter_path: "src/adapters/session-fixture/fail.yaml",
       },
     });
+  });
+
+  it("records runtime permission denies as redacted trace decisions", async () => {
+    const store = createRunStore({ rootDir: join(tmp, "runs") });
+    const rulesPath = join(tmp, "permission-rules.json");
+    writeFileSync(
+      rulesPath,
+      JSON.stringify({
+        schema_version: "1",
+        rules: [
+          {
+            id: "deny-blocked-runtime",
+            decision: "deny",
+            match: {
+              resources: { domains: ["blocked.example"] },
+            },
+            reason: "runtime domain is blocked",
+          },
+        ],
+      }),
+      "utf-8",
+    );
+    process.env.UNICLI_PERMISSION_RULES_PATH = rulesPath;
+    const inv = buildInvocation("cli", "session-fixture", "runtime-deny", {
+      args: {},
+      source: "shell",
+    })!;
+
+    const result = await executeWithRunRecording(inv, {
+      enabled: true,
+      store,
+      runId: "run-runtime-denied",
+    });
+
+    expect(result.error?.code).toBe("permission_denied");
+    const events = await readRunEvents(store, "run-runtime-denied");
+    expect(events.map((event) => event.name)).toEqual([
+      "run.started",
+      "tool.call.started",
+      "permission.evaluated",
+      "permission.runtime_denied",
+      "tool.call.failed",
+      "evidence.captured",
+      "run.failed",
+    ]);
+    expect(events.map((event) => event.sequence)).toEqual([
+      1, 2, 3, 4, 5, 6, 7,
+    ]);
+    const runtimeDenied = events.find(
+      (event) => event.name === "permission.runtime_denied",
+    );
+    expect(runtimeDenied?.data).toMatchObject({
+      code: "permission_denied",
+      adapter_path: "src/adapters/session-fixture/runtime-deny.yaml",
+      action: "fetch_text",
+      step: 0,
+      rule_id: "deny-blocked-runtime",
+      resource_buckets: ["domains"],
+      retryable: false,
+    });
+    expect(runtimeDenied?.internal).toEqual({
+      resources: { domains: ["blocked.example"] },
+    });
+    expect(runtimeDenied).not.toHaveProperty("secret");
+    expect(JSON.stringify(runtimeDenied?.data)).not.toContain(
+      "/secret?token=hidden",
+    );
   });
 
   it("records structured permission config errors before execution", async () => {


### PR DESCRIPTION
## What changed

- Records `permission.runtime_denied` events when runtime deny rules block pipeline resources.
- Adds kernel diagnostics for rule id, action, step, and resource buckets; raw resources stay in internal trace payloads.
- Adds `runs compare` checks for runtime deny rule, action, step, and resource bucket drift.
- Refreshes test stats and adds a changeset.

## Validation

- `pnpm verify:clean`
- pre-push hook ran `pnpm verify:clean` again