### PR TITLE
feat: summarize runtime permission denies

### DIFF
--- a/.changeset/runtime-deny-summaries.md
+++ b/.changeset/runtime-deny-summaries.md
@@ -1,0 +1,5 @@
+---
+"@zenalexa/unicli": minor
+---
+
+Surface runtime permission deny summaries in recorded run lists and show output, with only the denied code, action, step, rule, retry flag, and resource bucket names exposed.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 </p>
 
 <p align="center">
-  <sub><!-- STATS:site_count -->235<!-- /STATS --> sites · <!-- STATS:command_count -->1448<!-- /STATS --> commands · <!-- STATS:pipeline_step_count -->59<!-- /STATS --> pipeline steps · <!-- STATS:test_count -->7560<!-- /STATS --> tests</sub>
+  <sub><!-- STATS:site_count -->235<!-- /STATS --> sites · <!-- STATS:command_count -->1448<!-- /STATS --> commands · <!-- STATS:pipeline_step_count -->59<!-- /STATS --> pipeline steps · <!-- STATS:test_count -->7562<!-- /STATS --> tests</sub>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 </p>
 
 <p align="center">
-  <sub><!-- STATS:site_count -->235<!-- /STATS --> sites · <!-- STATS:command_count -->1448<!-- /STATS --> commands · <!-- STATS:pipeline_step_count -->59<!-- /STATS --> pipeline steps · <!-- STATS:test_count -->7562<!-- /STATS --> tests</sub>
+  <sub><!-- STATS:site_count -->235<!-- /STATS --> sites · <!-- STATS:command_count -->1448<!-- /STATS --> commands · <!-- STATS:pipeline_step_count -->59<!-- /STATS --> pipeline steps · <!-- STATS:test_count -->7563<!-- /STATS --> tests</sub>
 </p>
 
 <p align="center">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -28,7 +28,7 @@
 </p>
 
 <p align="center">
-  <sub><!-- STATS:site_count -->235<!-- /STATS --> 个站点 · <!-- STATS:command_count -->1448<!-- /STATS --> 条命令 · <!-- STATS:pipeline_step_count -->59<!-- /STATS --> 个 pipeline step · <!-- STATS:test_count -->7562<!-- /STATS --> 个测试</sub>
+  <sub><!-- STATS:site_count -->235<!-- /STATS --> 个站点 · <!-- STATS:command_count -->1448<!-- /STATS --> 条命令 · <!-- STATS:pipeline_step_count -->59<!-- /STATS --> 个 pipeline step · <!-- STATS:test_count -->7563<!-- /STATS --> 个测试</sub>
 </p>
 
 <p align="center">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -28,7 +28,7 @@
 </p>
 
 <p align="center">
-  <sub><!-- STATS:site_count -->235<!-- /STATS --> 个站点 · <!-- STATS:command_count -->1448<!-- /STATS --> 条命令 · <!-- STATS:pipeline_step_count -->59<!-- /STATS --> 个 pipeline step · <!-- STATS:test_count -->7560<!-- /STATS --> 个测试</sub>
+  <sub><!-- STATS:site_count -->235<!-- /STATS --> 个站点 · <!-- STATS:command_count -->1448<!-- /STATS --> 条命令 · <!-- STATS:pipeline_step_count -->59<!-- /STATS --> 个 pipeline step · <!-- STATS:test_count -->7562<!-- /STATS --> 个测试</sub>
 </p>
 
 <p align="center">

--- a/contributing/COPY.md
+++ b/contributing/COPY.md
@@ -2,7 +2,7 @@
 
 > Current version: v0.217.0 — Apollo · Lovell.
 >
-> Current scale: <!-- STATS:site_count -->235<!-- /STATS --> sites, <!-- STATS:command_count -->1448<!-- /STATS --> commands, <!-- STATS:adapter_count_total -->1039<!-- /STATS --> adapters (<!-- STATS:adapter_count_yaml -->917<!-- /STATS --> YAML + <!-- STATS:adapter_count_ts -->122<!-- /STATS --> TS), <!-- STATS:test_count -->7560<!-- /STATS --> tests.
+> Current scale: <!-- STATS:site_count -->235<!-- /STATS --> sites, <!-- STATS:command_count -->1448<!-- /STATS --> commands, <!-- STATS:adapter_count_total -->1039<!-- /STATS --> adapters (<!-- STATS:adapter_count_yaml -->917<!-- /STATS --> YAML + <!-- STATS:adapter_count_ts -->122<!-- /STATS --> TS), <!-- STATS:test_count -->7562<!-- /STATS --> tests.
 
 This file keeps docs and user-facing copy consistent. Public pages should expose
 install, command, output, and repair facts with the fewest words needed.

--- a/contributing/COPY.md
+++ b/contributing/COPY.md
@@ -2,7 +2,7 @@
 
 > Current version: v0.217.0 — Apollo · Lovell.
 >
-> Current scale: <!-- STATS:site_count -->235<!-- /STATS --> sites, <!-- STATS:command_count -->1448<!-- /STATS --> commands, <!-- STATS:adapter_count_total -->1039<!-- /STATS --> adapters (<!-- STATS:adapter_count_yaml -->917<!-- /STATS --> YAML + <!-- STATS:adapter_count_ts -->122<!-- /STATS --> TS), <!-- STATS:test_count -->7562<!-- /STATS --> tests.
+> Current scale: <!-- STATS:site_count -->235<!-- /STATS --> sites, <!-- STATS:command_count -->1448<!-- /STATS --> commands, <!-- STATS:adapter_count_total -->1039<!-- /STATS --> adapters (<!-- STATS:adapter_count_yaml -->917<!-- /STATS --> YAML + <!-- STATS:adapter_count_ts -->122<!-- /STATS --> TS), <!-- STATS:test_count -->7563<!-- /STATS --> tests.
 
 This file keeps docs and user-facing copy consistent. Public pages should expose
 install, command, output, and repair facts with the fewest words needed.

--- a/src/engine/session/query.ts
+++ b/src/engine/session/query.ts
@@ -34,6 +34,16 @@ export interface RunSummary {
   lease_owner?: string;
   lease_scope?: string;
   error_code?: string;
+  runtime_permission_denied?: RunSummaryRuntimePermissionDenied;
+}
+
+export interface RunSummaryRuntimePermissionDenied {
+  code?: string;
+  action?: string;
+  step?: number;
+  rule_id?: string;
+  resource_buckets?: string[];
+  retryable?: boolean;
 }
 
 export async function listRunSummaries(store: RunStore): Promise<RunSummary[]> {
@@ -88,26 +98,26 @@ export function summarizeRunEvents(
   events: RunEvent[],
   options: { runId?: RunId; updatedAt?: string } = {},
 ): RunSummary {
-  return summarizeRunEventScan(
-    {
-      first: events[0],
-      started: events.find((event) => event.name === "run.started"),
-      terminal: [...events]
-        .reverse()
-        .find(
-          (event) =>
-            event.name === "run.completed" || event.name === "run.failed",
-        ),
-      events: events.length,
-    },
-    options,
-  );
+  const scan: RunEventScan = { first: events[0], events: events.length };
+  for (const event of events) {
+    if (!scan.started && event.name === "run.started") {
+      scan.started = event;
+    }
+    if (event.name === "run.completed" || event.name === "run.failed") {
+      scan.terminal = event;
+    }
+    if (event.name === "permission.runtime_denied") {
+      scan.runtimePermissionDenied = event;
+    }
+  }
+  return summarizeRunEventScan(scan, options);
 }
 
 interface RunEventScan {
   first?: RunEvent;
   started?: RunEvent;
   terminal?: RunEvent;
+  runtimePermissionDenied?: RunEvent;
   events: number;
 }
 
@@ -146,6 +156,9 @@ async function summarizeRunTraceFile(
       if (event.name === "run.completed" || event.name === "run.failed") {
         scan.terminal = event;
       }
+      if (event.name === "permission.runtime_denied") {
+        scan.runtimePermissionDenied = event;
+      }
     }
   } catch (err) {
     if (err instanceof RunStoreError) throw err;
@@ -169,6 +182,9 @@ function summarizeRunEventScan(
   const terminal = scan.terminal;
   const started = scan.started;
   const lease = metadata?.browser_lease;
+  const runtimeDenied = runtimePermissionDeniedSummary(
+    scan.runtimePermissionDenied,
+  );
   const summary: RunSummary = {
     run_id: options.runId ?? metadata?.run_id ?? first?.run_id ?? "unknown",
     command: metadata?.command,
@@ -183,12 +199,62 @@ function summarizeRunEventScan(
     ...(metadata?.target_surface
       ? { target_surface: String(metadata.target_surface) }
       : {}),
+    ...(runtimeDenied ? { runtime_permission_denied: runtimeDenied } : {}),
     ...browserLeaseSummary(lease),
   };
   const durationMs = runDurationMs(summary.started_at, summary.finished_at);
   return durationMs === undefined
     ? summary
     : { ...summary, duration_ms: durationMs };
+}
+
+function runtimePermissionDeniedSummary(
+  event?: RunEvent,
+): RunSummaryRuntimePermissionDenied | undefined {
+  if (!event) return undefined;
+  const code = stringDataField(event, "code");
+  const action = stringDataField(event, "action");
+  const step = numberDataField(event, "step");
+  const ruleId = stringDataField(event, "rule_id");
+  const resourceBuckets = stringArrayDataField(event, "resource_buckets");
+  const retryable = booleanDataField(event, "retryable");
+  return {
+    ...(code ? { code } : {}),
+    ...(action ? { action } : {}),
+    ...(step !== undefined ? { step } : {}),
+    ...(ruleId ? { rule_id: ruleId } : {}),
+    ...(resourceBuckets ? { resource_buckets: resourceBuckets } : {}),
+    ...(retryable !== undefined ? { retryable } : {}),
+  };
+}
+
+function stringDataField(event: RunEvent, field: string): string | undefined {
+  const value = event.data?.[field];
+  return typeof value === "string" ? value : undefined;
+}
+
+function numberDataField(event: RunEvent, field: string): number | undefined {
+  const value = event.data?.[field];
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function booleanDataField(event: RunEvent, field: string): boolean | undefined {
+  const value = event.data?.[field];
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function stringArrayDataField(
+  event: RunEvent,
+  field: string,
+): string[] | undefined {
+  const value = event.data?.[field];
+  if (!Array.isArray(value)) return undefined;
+  const values = value.filter((entry): entry is string => {
+    return typeof entry === "string";
+  });
+  return values.length > 0 ? values : undefined;
 }
 
 export function projectRunEvents(

--- a/src/engine/session/query.ts
+++ b/src/engine/session/query.ts
@@ -218,14 +218,35 @@ function runtimePermissionDeniedSummary(
   const ruleId = stringDataField(event, "rule_id");
   const resourceBuckets = stringArrayDataField(event, "resource_buckets");
   const retryable = booleanDataField(event, "retryable");
-  return {
-    ...(code ? { code } : {}),
-    ...(action ? { action } : {}),
-    ...(step !== undefined ? { step } : {}),
-    ...(ruleId ? { rule_id: ruleId } : {}),
-    ...(resourceBuckets ? { resource_buckets: resourceBuckets } : {}),
-    ...(retryable !== undefined ? { retryable } : {}),
-  };
+  const summary: RunSummaryRuntimePermissionDenied = {};
+  let hasValue = false;
+
+  if (code) {
+    summary.code = code;
+    hasValue = true;
+  }
+  if (action) {
+    summary.action = action;
+    hasValue = true;
+  }
+  if (step !== undefined) {
+    summary.step = step;
+    hasValue = true;
+  }
+  if (ruleId) {
+    summary.rule_id = ruleId;
+    hasValue = true;
+  }
+  if (resourceBuckets) {
+    summary.resource_buckets = resourceBuckets;
+    hasValue = true;
+  }
+  if (retryable !== undefined) {
+    summary.retryable = retryable;
+    hasValue = true;
+  }
+
+  return hasValue ? summary : undefined;
 }
 
 function stringDataField(event: RunEvent, field: string): string | undefined {

--- a/stats.json
+++ b/stats.json
@@ -4,7 +4,7 @@
   "adapter_count_total": 1039,
   "site_count": 235,
   "command_count": 1448,
-  "test_count": 7562,
+  "test_count": 7563,
   "pipeline_step_count": 59,
   "transport_count": 3,
   "app_transport_count": 7,

--- a/stats.json
+++ b/stats.json
@@ -4,7 +4,7 @@
   "adapter_count_total": 1039,
   "site_count": 235,
   "command_count": 1448,
-  "test_count": 7560,
+  "test_count": 7562,
   "pipeline_step_count": 59,
   "transport_count": 3,
   "app_transport_count": 7,

--- a/tests/unit/session-query.test.ts
+++ b/tests/unit/session-query.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createRunEventSequence,
+  createRunStartedEvent,
+  createRuntimePermissionDeniedEvent,
+  type RunTraceMetadata,
+} from "../../src/engine/session/events.js";
+import { summarizeRunEvents } from "../../src/engine/session/query.js";
+
+const metadata: RunTraceMetadata = {
+  run_id: "run-query-01",
+  trace_id: "01HXTRACEQUERY00000000000",
+  command: "demo.fetch",
+  site: "demo",
+  cmd: "fetch",
+  adapter_path: "src/adapters/demo/fetch.yaml",
+  permission_profile: "locked",
+  transport_surface: "cli",
+  target_surface: "web",
+  args_hash: "sha256:query",
+  pipeline_steps: 1,
+};
+
+describe("session run summaries", () => {
+  it("omits runtime permission deny summaries with no public fields", () => {
+    const sequence = createRunEventSequence();
+    const events = [
+      createRunStartedEvent(metadata, sequence),
+      createRuntimePermissionDeniedEvent(
+        metadata,
+        sequence,
+        {
+          adapter_path: metadata.adapter_path,
+        },
+        {
+          resources: {
+            urls: ["https://blocked.example/secret?token=hidden"],
+          },
+        },
+      ),
+    ];
+
+    const summary = summarizeRunEvents(events);
+
+    expect(summary).not.toHaveProperty("runtime_permission_denied");
+    expect(JSON.stringify(summary)).not.toContain("blocked.example");
+  });
+});

--- a/tests/unit/session-runs-command.test.ts
+++ b/tests/unit/session-runs-command.test.ts
@@ -7,6 +7,7 @@ import { Command } from "commander";
 import { createBrowserSessionLease } from "../../src/engine/browser/session-lease.js";
 import {
   createEvidenceCapturedEvent,
+  createRuntimePermissionDeniedEvent,
   createRunCompletedEvent,
   createRunEventSequence,
   createRunFailedEvent,
@@ -148,6 +149,77 @@ describe("unicli runs command", () => {
     await appendRunEvent(store, {
       ...createRunCompletedEvent(metadata, sequence, { status: "ok" }),
       timestamp: "2026-04-29T01:00:02.000Z",
+    });
+    return metadata.run_id;
+  }
+
+  async function writeRuntimeDeniedRun(rootDir: string): Promise<string> {
+    const store = createRunStore({ rootDir });
+    const metadata: RunTraceMetadata = {
+      run_id: "run-runtime-denied-01",
+      trace_id: "01HTRACERUNTIME000000000",
+      command: "browser.fetch",
+      site: "browser",
+      cmd: "fetch",
+      adapter_path: "src/adapters/browser/fetch.yaml",
+      permission_profile: "locked",
+      transport_surface: "cli",
+      target_surface: "web",
+      args_hash: "sha256:runtime-denied",
+      pipeline_steps: 1,
+    };
+    const sequence = createRunEventSequence();
+    const error = {
+      code: "permission_denied",
+      message: "runtime domain is blocked",
+      adapter_path: metadata.adapter_path,
+    };
+    const resultData = {
+      exit_code: 77,
+      result_count: 0,
+      duration_ms: 16,
+      error,
+      envelope: { command: "browser.fetch", error },
+    };
+    await appendRunEvent(
+      store,
+      createRunStartedEvent(metadata, sequence, {
+        timestamp: "2026-04-29T01:10:00.000Z",
+      }),
+    );
+    await appendRunEvent(store, {
+      ...createToolCallStartedEvent(metadata, sequence),
+      timestamp: "2026-04-29T01:10:01.000Z",
+    });
+    await appendRunEvent(store, {
+      ...createRuntimePermissionDeniedEvent(
+        metadata,
+        sequence,
+        {
+          code: "permission_denied",
+          adapter_path: metadata.adapter_path,
+          action: "fetch_text",
+          step: 0,
+          rule_id: "deny-blocked-runtime",
+          resource_buckets: ["domains", "urls"],
+          retryable: false,
+        },
+        {
+          resources: {
+            domains: ["blocked.example"],
+            urls: ["https://blocked.example/secret?token=hidden"],
+          },
+        },
+      ),
+      timestamp: "2026-04-29T01:10:02.000Z",
+    });
+    await appendRunEvent(store, {
+      ...createToolCallFailedEvent(metadata, sequence, resultData),
+      timestamp: "2026-04-29T01:10:03.000Z",
+    });
+    await appendRunEvent(store, {
+      ...createRunFailedEvent(metadata, sequence, resultData),
+      timestamp: "2026-04-29T01:10:04.000Z",
     });
     return metadata.run_id;
   }
@@ -343,6 +415,51 @@ describe("unicli runs command", () => {
     expect(env.data.runs[0].browser_session_id).toMatch(/^browser-session:/);
   });
 
+  it("lists runtime permission deny summaries without raw resources", async () => {
+    const rootDir = join(tmp, "runs");
+    await writeRuntimeDeniedRun(rootDir);
+
+    const cap = captureConsole();
+    try {
+      const program = createProgram();
+      await program.parseAsync(
+        ["-f", "json", "runs", "list", "--root", rootDir],
+        { from: "user" },
+      );
+    } finally {
+      cap.restore();
+    }
+
+    const env = JSON.parse(cap.getStdout().trim()) as {
+      data: {
+        runs: Array<{
+          run_id: string;
+          runtime_permission_denied?: {
+            code: string;
+            action: string;
+            step: number;
+            rule_id: string;
+            resource_buckets: string[];
+            retryable: boolean;
+          };
+        }>;
+      };
+    };
+    expect(env.data.runs[0]).toMatchObject({
+      run_id: "run-runtime-denied-01",
+      runtime_permission_denied: {
+        code: "permission_denied",
+        action: "fetch_text",
+        step: 0,
+        rule_id: "deny-blocked-runtime",
+        resource_buckets: ["domains", "urls"],
+        retryable: false,
+      },
+    });
+    expect(cap.getStdout()).not.toContain("blocked.example");
+    expect(cap.getStdout()).not.toContain("/secret?token=hidden");
+  });
+
   it("skips unexpected run directories with invalid ids", async () => {
     const rootDir = join(tmp, "runs");
     await writeBrowserRun(rootDir);
@@ -424,6 +541,47 @@ describe("unicli runs command", () => {
     expect(env.data.events).toHaveLength(3);
     expect(env.data.events[1]).not.toHaveProperty("internal");
     expect(env.data.events[1]).not.toHaveProperty("secret");
+  });
+
+  it("shows runtime permission deny summaries without raw resources", async () => {
+    const rootDir = join(tmp, "runs");
+    const runId = await writeRuntimeDeniedRun(rootDir);
+
+    const cap = captureConsole();
+    try {
+      const program = createProgram();
+      await program.parseAsync(
+        ["-f", "json", "runs", "show", runId, "--root", rootDir],
+        { from: "user" },
+      );
+    } finally {
+      cap.restore();
+    }
+
+    const env = JSON.parse(cap.getStdout().trim()) as {
+      data: {
+        summary: {
+          runtime_permission_denied?: {
+            code: string;
+            action: string;
+            step: number;
+            rule_id: string;
+            resource_buckets: string[];
+            retryable: boolean;
+          };
+        };
+      };
+    };
+    expect(env.data.summary.runtime_permission_denied).toEqual({
+      code: "permission_denied",
+      action: "fetch_text",
+      step: 0,
+      rule_id: "deny-blocked-runtime",
+      resource_buckets: ["domains", "urls"],
+      retryable: false,
+    });
+    expect(cap.getStdout()).not.toContain("blocked.example");
+    expect(cap.getStdout()).not.toContain("/secret?token=hidden");
   });
 
   it("can include internal event payloads while still redacting secret payloads", async () => {


### PR DESCRIPTION
## Summary
- Add `runtime_permission_denied` to recorded run summaries from JSONL traces and in-memory event arrays.
- Expose low-sensitivity deny fields: code, action, step, rule id, retry flag, and resource bucket names.
- Cover `runs list` and `runs show` JSON output with redaction tests.

## Checks
- `pnpm exec vitest run --project unit tests/unit/session-runs-command.test.ts`
- `pnpm exec vitest run --project unit tests/unit/session-runs-command.test.ts tests/unit/session-compare.test.ts tests/unit/session-events.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm stats:check`
- `pnpm verify:changesets`
- `pnpm verify:clean`
- pre-push `pnpm verify:clean`