### PR TITLE
feat: stream recorded run events

### DIFF
--- a/.changeset/run-event-stream.md
+++ b/.changeset/run-event-stream.md
@@ -1,0 +1,5 @@
+---
+"@zenalexa/unicli": minor
+---
+
+Add `unicli runs stream <run_id>` for JSONL run-event streaming, with sequence cursors, follow mode, terminal stop, and the same public/internal redaction model as `runs show`.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 </p>
 
 <p align="center">
-  <sub><!-- STATS:site_count -->235<!-- /STATS --> sites · <!-- STATS:command_count -->1448<!-- /STATS --> commands · <!-- STATS:pipeline_step_count -->59<!-- /STATS --> pipeline steps · <!-- STATS:test_count -->7565<!-- /STATS --> tests</sub>
+  <sub><!-- STATS:site_count -->235<!-- /STATS --> sites · <!-- STATS:command_count -->1448<!-- /STATS --> commands · <!-- STATS:pipeline_step_count -->59<!-- /STATS --> pipeline steps · <!-- STATS:test_count -->7567<!-- /STATS --> tests</sub>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 </p>
 
 <p align="center">
-  <sub><!-- STATS:site_count -->235<!-- /STATS --> sites · <!-- STATS:command_count -->1448<!-- /STATS --> commands · <!-- STATS:pipeline_step_count -->59<!-- /STATS --> pipeline steps · <!-- STATS:test_count -->7563<!-- /STATS --> tests</sub>
+  <sub><!-- STATS:site_count -->235<!-- /STATS --> sites · <!-- STATS:command_count -->1448<!-- /STATS --> commands · <!-- STATS:pipeline_step_count -->59<!-- /STATS --> pipeline steps · <!-- STATS:test_count -->7565<!-- /STATS --> tests</sub>
 </p>
 
 <p align="center">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -28,7 +28,7 @@
 </p>
 
 <p align="center">
-  <sub><!-- STATS:site_count -->235<!-- /STATS --> 个站点 · <!-- STATS:command_count -->1448<!-- /STATS --> 条命令 · <!-- STATS:pipeline_step_count -->59<!-- /STATS --> 个 pipeline step · <!-- STATS:test_count -->7563<!-- /STATS --> 个测试</sub>
+  <sub><!-- STATS:site_count -->235<!-- /STATS --> 个站点 · <!-- STATS:command_count -->1448<!-- /STATS --> 条命令 · <!-- STATS:pipeline_step_count -->59<!-- /STATS --> 个 pipeline step · <!-- STATS:test_count -->7565<!-- /STATS --> 个测试</sub>
 </p>
 
 <p align="center">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -28,7 +28,7 @@
 </p>
 
 <p align="center">
-  <sub><!-- STATS:site_count -->235<!-- /STATS --> 个站点 · <!-- STATS:command_count -->1448<!-- /STATS --> 条命令 · <!-- STATS:pipeline_step_count -->59<!-- /STATS --> 个 pipeline step · <!-- STATS:test_count -->7565<!-- /STATS --> 个测试</sub>
+  <sub><!-- STATS:site_count -->235<!-- /STATS --> 个站点 · <!-- STATS:command_count -->1448<!-- /STATS --> 条命令 · <!-- STATS:pipeline_step_count -->59<!-- /STATS --> 个 pipeline step · <!-- STATS:test_count -->7567<!-- /STATS --> 个测试</sub>
 </p>
 
 <p align="center">

--- a/contributing/COPY.md
+++ b/contributing/COPY.md
@@ -2,7 +2,7 @@
 
 > Current version: v0.217.0 — Apollo · Lovell.
 >
-> Current scale: <!-- STATS:site_count -->235<!-- /STATS --> sites, <!-- STATS:command_count -->1448<!-- /STATS --> commands, <!-- STATS:adapter_count_total -->1039<!-- /STATS --> adapters (<!-- STATS:adapter_count_yaml -->917<!-- /STATS --> YAML + <!-- STATS:adapter_count_ts -->122<!-- /STATS --> TS), <!-- STATS:test_count -->7563<!-- /STATS --> tests.
+> Current scale: <!-- STATS:site_count -->235<!-- /STATS --> sites, <!-- STATS:command_count -->1448<!-- /STATS --> commands, <!-- STATS:adapter_count_total -->1039<!-- /STATS --> adapters (<!-- STATS:adapter_count_yaml -->917<!-- /STATS --> YAML + <!-- STATS:adapter_count_ts -->122<!-- /STATS --> TS), <!-- STATS:test_count -->7565<!-- /STATS --> tests.
 
 This file keeps docs and user-facing copy consistent. Public pages should expose
 install, command, output, and repair facts with the fewest words needed.

--- a/contributing/COPY.md
+++ b/contributing/COPY.md
@@ -2,7 +2,7 @@
 
 > Current version: v0.217.0 — Apollo · Lovell.
 >
-> Current scale: <!-- STATS:site_count -->235<!-- /STATS --> sites, <!-- STATS:command_count -->1448<!-- /STATS --> commands, <!-- STATS:adapter_count_total -->1039<!-- /STATS --> adapters (<!-- STATS:adapter_count_yaml -->917<!-- /STATS --> YAML + <!-- STATS:adapter_count_ts -->122<!-- /STATS --> TS), <!-- STATS:test_count -->7565<!-- /STATS --> tests.
+> Current scale: <!-- STATS:site_count -->235<!-- /STATS --> sites, <!-- STATS:command_count -->1448<!-- /STATS --> commands, <!-- STATS:adapter_count_total -->1039<!-- /STATS --> adapters (<!-- STATS:adapter_count_yaml -->917<!-- /STATS --> YAML + <!-- STATS:adapter_count_ts -->122<!-- /STATS --> TS), <!-- STATS:test_count -->7567<!-- /STATS --> tests.
 
 This file keeps docs and user-facing copy consistent. Public pages should expose
 install, command, output, and repair facts with the fewest words needed.

--- a/src/commands/runs.ts
+++ b/src/commands/runs.ts
@@ -86,6 +86,12 @@ function nonNegativeInteger(
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
 }
 
+function runStoreAgentErrorCode(error: RunStoreError): string {
+  return error.code === "invalid_run_id" || error.code === "malformed_jsonl"
+    ? "invalid_input"
+    : "internal_error";
+}
+
 export function registerRunsCommand(program: Command): void {
   const runs = program
     .command("runs")
@@ -171,10 +177,7 @@ export function registerRunsCommand(program: Command): void {
       } catch (err) {
         if (err instanceof RunStoreError) {
           printRunError(program, "runs.stream", startedAt, {
-            code:
-              err.code === "invalid_run_id"
-                ? "invalid_input"
-                : "internal_error",
+            code: runStoreAgentErrorCode(err),
             message: err.message,
             suggestion: "run `unicli runs list` and choose an existing run id",
             retryable: false,

--- a/src/commands/runs.ts
+++ b/src/commands/runs.ts
@@ -8,6 +8,7 @@ import {
   readRunEvents,
   runTracePath,
   RunStoreError,
+  watchRunEvents,
 } from "../engine/session/store.js";
 import {
   listRunSummaries,
@@ -30,6 +31,15 @@ interface RunsListOptions {
 interface RunsShowOptions {
   root?: string;
   includeInternal?: boolean;
+}
+
+interface RunsStreamOptions {
+  root?: string;
+  after?: string;
+  follow?: boolean;
+  includeInternal?: boolean;
+  pollMs?: string;
+  timeoutMs?: string;
 }
 
 interface RunsProbeOptions {
@@ -65,6 +75,15 @@ function printRunError(
       error,
     }),
   );
+}
+
+function nonNegativeInteger(
+  value: string | undefined,
+  fallback: number,
+): number {
+  if (value === undefined) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
 }
 
 export function registerRunsCommand(program: Command): void {
@@ -123,6 +142,47 @@ export function registerRunsCommand(program: Command): void {
           ctx,
         ),
       );
+    });
+
+  runs
+    .command("stream <run_id>")
+    .description("Stream recorded run trace events as JSON lines")
+    .option("--root <path>", "Override run trace root")
+    .option("--after <sequence>", "Only stream events after this sequence", "0")
+    .option("--follow", "Poll until the run reaches a terminal event")
+    .option("--include-internal", "Include internal event payloads")
+    .option("--poll-ms <ms>", "Follow poll interval in milliseconds", "250")
+    .option("--timeout-ms <ms>", "Follow timeout in milliseconds", "30000")
+    .action(async (runId: string, opts: RunsStreamOptions) => {
+      const startedAt = Date.now();
+      const store = createRunStore({ rootDir: opts.root });
+      try {
+        for await (const event of watchRunEvents(store, runId, {
+          afterSequence: nonNegativeInteger(opts.after, 0),
+          follow: opts.follow === true,
+          pollIntervalMs: nonNegativeInteger(opts.pollMs, 250),
+          timeoutMs: nonNegativeInteger(opts.timeoutMs, 30_000),
+        })) {
+          const [projected] = projectRunEvents([event], {
+            includeInternal: opts.includeInternal === true,
+          });
+          console.log(JSON.stringify(projected));
+        }
+      } catch (err) {
+        if (err instanceof RunStoreError) {
+          printRunError(program, "runs.stream", startedAt, {
+            code:
+              err.code === "invalid_run_id"
+                ? "invalid_input"
+                : "internal_error",
+            message: err.message,
+            suggestion: "run `unicli runs list` and choose an existing run id",
+            retryable: false,
+          });
+          return;
+        }
+        throw err;
+      }
     });
 
   runs

--- a/src/engine/session/store.ts
+++ b/src/engine/session/store.ts
@@ -1,11 +1,19 @@
 import { mkdir, readFile, appendFile, chmod } from "node:fs/promises";
 import { existsSync } from "node:fs";
+import { setTimeout as delay } from "node:timers/promises";
 import { dirname, join } from "node:path";
 import { userHome } from "../user-home.js";
 import type { RunEvent, RunId } from "./types.js";
 
 export interface RunStore {
   rootDir: string;
+}
+
+export interface WatchRunEventsOptions {
+  afterSequence?: number;
+  follow?: boolean;
+  pollIntervalMs?: number;
+  timeoutMs?: number;
 }
 
 export type RunStoreErrorCode =
@@ -116,4 +124,47 @@ export async function readRunEvents(
     }
   });
   return events;
+}
+
+export async function* watchRunEvents(
+  store: RunStore,
+  runId: RunId,
+  options: WatchRunEventsOptions = {},
+): AsyncGenerator<RunEvent> {
+  const follow = options.follow === true;
+  const pollIntervalMs = Math.max(1, options.pollIntervalMs ?? 250);
+  const timeoutMs = Math.max(0, options.timeoutMs ?? 30_000);
+  const deadline = follow ? Date.now() + timeoutMs : undefined;
+  let afterSequence = Math.max(0, Math.floor(options.afterSequence ?? 0));
+
+  while (true) {
+    const events = await readRunEvents(store, runId);
+    const nextEvents = events
+      .filter((event) => event.sequence > afterSequence)
+      .sort((a, b) => a.sequence - b.sequence);
+    let yieldedTerminal = false;
+
+    for (const event of nextEvents) {
+      yield event;
+      afterSequence = Math.max(afterSequence, event.sequence);
+      if (isTerminalRunEvent(event)) {
+        yieldedTerminal = true;
+      }
+    }
+
+    if (!follow || yieldedTerminal) return;
+    if (events.some((event) => isTerminalRunEvent(event))) return;
+    if (deadline !== undefined && Date.now() >= deadline) return;
+
+    const waitMs =
+      deadline === undefined
+        ? pollIntervalMs
+        : Math.min(pollIntervalMs, Math.max(0, deadline - Date.now()));
+    if (waitMs <= 0) return;
+    await delay(waitMs);
+  }
+}
+
+function isTerminalRunEvent(event: RunEvent): boolean {
+  return event.name === "run.completed" || event.name === "run.failed";
 }

--- a/src/engine/session/store.ts
+++ b/src/engine/session/store.ts
@@ -1,5 +1,13 @@
-import { mkdir, readFile, appendFile, chmod } from "node:fs/promises";
+import {
+  mkdir,
+  readFile,
+  appendFile,
+  chmod,
+  open,
+  stat,
+} from "node:fs/promises";
 import { existsSync } from "node:fs";
+import { StringDecoder } from "node:string_decoder";
 import { setTimeout as delay } from "node:timers/promises";
 import { dirname, join } from "node:path";
 import { userHome } from "../user-home.js";
@@ -31,6 +39,18 @@ export class RunStoreError extends Error {
     super(message);
     this.name = "RunStoreError";
   }
+}
+
+interface RunEventTailState {
+  offset: number;
+  partialLine: string;
+  nextLineNumber: number;
+  decoder: StringDecoder;
+}
+
+interface ReadAppendedRunEventsResult {
+  events: RunEvent[];
+  sawTerminal: boolean;
 }
 
 export function createRunStore(
@@ -137,9 +157,28 @@ export async function* watchRunEvents(
   const deadline = follow ? Date.now() + timeoutMs : undefined;
   let afterSequence = Math.max(0, Math.floor(options.afterSequence ?? 0));
 
-  while (true) {
+  if (!follow) {
     const events = await readRunEvents(store, runId);
     const nextEvents = events
+      .filter((event) => event.sequence > afterSequence)
+      .sort((a, b) => a.sequence - b.sequence);
+    for (const event of nextEvents) {
+      yield event;
+    }
+    return;
+  }
+
+  const path = runTracePath(store, runId);
+  const tailState: RunEventTailState = {
+    offset: 0,
+    partialLine: "",
+    nextLineNumber: 1,
+    decoder: new StringDecoder("utf8"),
+  };
+
+  while (true) {
+    const readResult = await readAppendedRunEvents(path, tailState);
+    const nextEvents = readResult.events
       .filter((event) => event.sequence > afterSequence)
       .sort((a, b) => a.sequence - b.sequence);
     let yieldedTerminal = false;
@@ -152,8 +191,7 @@ export async function* watchRunEvents(
       }
     }
 
-    if (!follow || yieldedTerminal) return;
-    if (events.some((event) => isTerminalRunEvent(event))) return;
+    if (yieldedTerminal || readResult.sawTerminal) return;
     if (deadline !== undefined && Date.now() >= deadline) return;
 
     const waitMs =
@@ -163,6 +201,103 @@ export async function* watchRunEvents(
     if (waitMs <= 0) return;
     await delay(waitMs);
   }
+}
+
+async function readAppendedRunEvents(
+  path: string,
+  state: RunEventTailState,
+): Promise<ReadAppendedRunEventsResult> {
+  const size = await traceFileSize(path);
+  if (size === undefined) return { events: [], sawTerminal: false };
+
+  if (size < state.offset) {
+    state.offset = 0;
+    state.partialLine = "";
+    state.nextLineNumber = 1;
+    state.decoder = new StringDecoder("utf8");
+  }
+  if (size === state.offset) return { events: [], sawTerminal: false };
+
+  const chunk = await readTraceChunk(path, state.offset, size - state.offset);
+  state.offset += chunk.byteLength;
+
+  const text = state.partialLine + state.decoder.write(chunk);
+  const lastNewlineIndex = text.lastIndexOf("\n");
+  if (lastNewlineIndex < 0) {
+    state.partialLine = text;
+    return { events: [], sawTerminal: false };
+  }
+
+  const completeText = text.slice(0, lastNewlineIndex + 1);
+  state.partialLine = text.slice(lastNewlineIndex + 1);
+  const lines = completeText.split(/\r?\n/);
+  const events: RunEvent[] = [];
+  let sawTerminal = false;
+
+  for (let index = 0; index < lines.length - 1; index += 1) {
+    const lineText = lines[index] ?? "";
+    const lineNumber = state.nextLineNumber;
+    state.nextLineNumber += 1;
+    if (lineText.trim().length === 0) continue;
+    try {
+      const event = JSON.parse(lineText) as RunEvent;
+      if (isTerminalRunEvent(event)) sawTerminal = true;
+      events.push(event);
+    } catch {
+      throw new RunStoreError(
+        "malformed_jsonl",
+        `malformed run trace JSONL at line ${lineNumber}`,
+        path,
+        lineNumber,
+      );
+    }
+  }
+
+  return { events, sawTerminal };
+}
+
+async function traceFileSize(path: string): Promise<number | undefined> {
+  try {
+    return (await stat(path)).size;
+  } catch (err) {
+    if (errorCode(err) === "ENOENT") return undefined;
+    const message = err instanceof Error ? err.message : String(err);
+    throw new RunStoreError(
+      "io_error",
+      `failed to stat run events: ${message}`,
+      path,
+    );
+  }
+}
+
+async function readTraceChunk(
+  path: string,
+  offset: number,
+  byteLength: number,
+): Promise<Buffer> {
+  let handle: Awaited<ReturnType<typeof open>> | undefined;
+  try {
+    handle = await open(path, "r");
+    const buffer = Buffer.alloc(byteLength);
+    const { bytesRead } = await handle.read(buffer, 0, byteLength, offset);
+    return buffer.subarray(0, bytesRead);
+  } catch (err) {
+    if (errorCode(err) === "ENOENT") return Buffer.alloc(0);
+    const message = err instanceof Error ? err.message : String(err);
+    throw new RunStoreError(
+      "io_error",
+      `failed to read run event tail: ${message}`,
+      path,
+    );
+  } finally {
+    await handle?.close();
+  }
+}
+
+function errorCode(err: unknown): string | undefined {
+  return typeof err === "object" && err !== null && "code" in err
+    ? String((err as { code?: unknown }).code)
+    : undefined;
 }
 
 function isTerminalRunEvent(event: RunEvent): boolean {

--- a/stats.json
+++ b/stats.json
@@ -4,7 +4,7 @@
   "adapter_count_total": 1039,
   "site_count": 235,
   "command_count": 1448,
-  "test_count": 7565,
+  "test_count": 7567,
   "pipeline_step_count": 59,
   "transport_count": 3,
   "app_transport_count": 7,

--- a/stats.json
+++ b/stats.json
@@ -4,7 +4,7 @@
   "adapter_count_total": 1039,
   "site_count": 235,
   "command_count": 1448,
-  "test_count": 7563,
+  "test_count": 7565,
   "pipeline_step_count": 59,
   "transport_count": 3,
   "app_transport_count": 7,

--- a/tests/unit/session-runs-command.test.ts
+++ b/tests/unit/session-runs-command.test.ts
@@ -584,6 +584,36 @@ describe("unicli runs command", () => {
     expect(cap.getStdout()).not.toContain("/secret?token=hidden");
   });
 
+  it("streams public run events as JSON lines after a sequence", async () => {
+    const rootDir = join(tmp, "runs");
+    const runId = await writeBrowserRun(rootDir);
+
+    const cap = captureConsole();
+    try {
+      const program = createProgram();
+      await program.parseAsync(
+        ["runs", "stream", runId, "--root", rootDir, "--after", "1"],
+        { from: "user" },
+      );
+    } finally {
+      cap.restore();
+    }
+
+    const lines = cap
+      .getStdout()
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(lines.map((event) => event.name)).toEqual([
+      "evidence.captured",
+      "run.completed",
+    ]);
+    expect(lines[0]).not.toHaveProperty("internal");
+    expect(lines[0]).not.toHaveProperty("secret");
+    expect(cap.getStdout()).not.toContain("private");
+    expect(cap.getStdout()).not.toContain("hidden");
+  });
+
   it("can include internal event payloads while still redacting secret payloads", async () => {
     const rootDir = join(tmp, "runs");
     const runId = await writeBrowserRun(rootDir);

--- a/tests/unit/session-runs-command.test.ts
+++ b/tests/unit/session-runs-command.test.ts
@@ -614,6 +614,43 @@ describe("unicli runs command", () => {
     expect(cap.getStdout()).not.toContain("hidden");
   });
 
+  it("reports malformed stream traces as invalid input", async () => {
+    const rootDir = join(tmp, "runs");
+    const brokenRunDir = join(rootDir, "run-broken-stream-01");
+    mkdirSync(brokenRunDir, { recursive: true });
+    writeFileSync(join(brokenRunDir, "trace.jsonl"), "{not json}\n");
+
+    const cap = captureConsole();
+    try {
+      const program = createProgram();
+      await program.parseAsync(
+        [
+          "-f",
+          "json",
+          "runs",
+          "stream",
+          "run-broken-stream-01",
+          "--root",
+          rootDir,
+        ],
+        { from: "user" },
+      );
+    } finally {
+      cap.restore();
+    }
+
+    const env = JSON.parse(cap.getStdout().trim()) as {
+      ok: boolean;
+      error: { code: string; message: string };
+    };
+    expect(env.ok).toBe(false);
+    expect(env.error).toMatchObject({
+      code: "invalid_input",
+      message: "malformed run trace JSONL at line 1",
+    });
+    expect(process.exitCode).toBe(ExitCode.USAGE_ERROR);
+  });
+
   it("can include internal event payloads while still redacting secret payloads", async () => {
     const rootDir = join(tmp, "runs");
     const runId = await writeBrowserRun(rootDir);

--- a/tests/unit/session-store.test.ts
+++ b/tests/unit/session-store.test.ts
@@ -8,10 +8,12 @@ import {
   rmSync,
   statSync,
 } from "node:fs";
+import { setTimeout as delay } from "node:timers/promises";
 import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 
 import {
+  createRunCompletedEvent,
   createRunEventSequence,
   createRunStartedEvent,
   type RunTraceMetadata,
@@ -22,6 +24,7 @@ import {
   readRunEvents,
   RunStoreError,
   runTracePath,
+  watchRunEvents,
 } from "../../src/engine/session/store.js";
 
 const metadata: RunTraceMetadata = {
@@ -148,5 +151,32 @@ describe("session JSONL store", () => {
       line: 1,
       path: tracePath,
     } satisfies Partial<RunStoreError>);
+  });
+
+  it("watches appended run events after a sequence until terminal", async () => {
+    const store = createRunStore({ rootDir: join(tmp, "runs") });
+    const sequence = createRunEventSequence();
+
+    const streamed = (async () => {
+      const names: string[] = [];
+      for await (const event of watchRunEvents(store, "run-store-01", {
+        afterSequence: 1,
+        follow: true,
+        pollIntervalMs: 5,
+        timeoutMs: 500,
+      })) {
+        names.push(event.name);
+      }
+      return names;
+    })();
+
+    await appendRunEvent(store, createRunStartedEvent(metadata, sequence));
+    await delay(20);
+    await appendRunEvent(
+      store,
+      createRunCompletedEvent(metadata, sequence, { status: "ok" }),
+    );
+
+    await expect(streamed).resolves.toEqual(["run.completed"]);
   });
 });

--- a/tests/unit/session-store.test.ts
+++ b/tests/unit/session-store.test.ts
@@ -179,4 +179,37 @@ describe("session JSONL store", () => {
 
     await expect(streamed).resolves.toEqual(["run.completed"]);
   });
+
+  it("waits for an unterminated trailing JSONL event in follow mode", async () => {
+    const store = createRunStore({ rootDir: join(tmp, "runs") });
+    const sequence = createRunEventSequence();
+    const started = createRunStartedEvent(metadata, sequence);
+    const completed = createRunCompletedEvent(metadata, sequence, {
+      status: "ok",
+    });
+    const tracePath = runTracePath(store, "run-store-01");
+    mkdirSync(dirname(tracePath), { recursive: true });
+    appendFileSync(tracePath, `${JSON.stringify(started)}\n`, "utf-8");
+
+    const streamed = (async () => {
+      const names: string[] = [];
+      for await (const event of watchRunEvents(store, "run-store-01", {
+        afterSequence: 1,
+        follow: true,
+        pollIntervalMs: 5,
+        timeoutMs: 500,
+      })) {
+        names.push(event.name);
+      }
+      return names;
+    })();
+
+    const completedLine = JSON.stringify(completed);
+    const splitAt = Math.floor(completedLine.length / 2);
+    appendFileSync(tracePath, completedLine.slice(0, splitAt), "utf-8");
+    await delay(20);
+    appendFileSync(tracePath, `${completedLine.slice(splitAt)}\n`, "utf-8");
+
+    await expect(streamed).resolves.toEqual(["run.completed"]);
+  });
 });


### PR DESCRIPTION
## Summary
- Add `watchRunEvents()` for cursor-based recorded-run event watching.
- Add `unicli runs stream <run_id>` for JSONL public event output with `--after`, `--follow`, `--poll-ms`, `--timeout-ms`, and `--include-internal`.
- Keep default stream output on the same public projection used by `runs show`, so `internal` and `secret` stay out of default JSONL.

## Checks
- Red test: `pnpm exec vitest run --project unit tests/unit/session-store.test.ts tests/unit/session-runs-command.test.ts`
- `pnpm exec vitest run --project unit tests/unit/session-store.test.ts tests/unit/session-runs-command.test.ts tests/unit/session-query.test.ts tests/unit/session-compare.test.ts tests/unit/session-events.test.ts`
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm stats:check`
- `pnpm verify:changesets`
- `pnpm verify:clean`
- pre-push `pnpm verify:clean`