### PR TITLE
feat: score run trace comparisons

### DIFF
--- a/.changeset/run-compare-score.md
+++ b/.changeset/run-compare-score.md
@@ -1,0 +1,5 @@
+---
+"@zenalexa/unicli": minor
+---
+
+Add numeric run comparison scores and `runs compare --min-score` so replay checks can fail CI when behavior drops below a reproducible threshold.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 </p>
 
 <p align="center">
-  <sub><!-- STATS:site_count -->235<!-- /STATS --> sites · <!-- STATS:command_count -->1448<!-- /STATS --> commands · <!-- STATS:pipeline_step_count -->59<!-- /STATS --> pipeline steps · <!-- STATS:test_count -->7567<!-- /STATS --> tests</sub>
+  <sub><!-- STATS:site_count -->235<!-- /STATS --> sites · <!-- STATS:command_count -->1448<!-- /STATS --> commands · <!-- STATS:pipeline_step_count -->59<!-- /STATS --> pipeline steps · <!-- STATS:test_count -->7569<!-- /STATS --> tests</sub>
 </p>
 
 <p align="center">
@@ -131,17 +131,17 @@ Prefer native CLI / JSON stream / MCP for agent runtimes. Use ACP as an editor c
 
 Uni-CLI sits under agent applications and turns software surfaces into commands that agents can discover, execute, record, and repair.
 
-| Surface            | What you get                                                                                                                                      |
-| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Websites and APIs  | Declarative adapters for public, cookie, header, and browser-intercept workflows                                                                  |
-| Browser automation | CDP steps for navigate, click, type, intercept, snapshot, extract, wait, and related browser work                                                 |
-| Desktop and macOS  | System commands, app adapters, screenshots, clipboard, calendar, brightness, and local tools                                                      |
-| External CLIs      | 58 registered pass-through bridges with install/status discovery                                                                                  |
-| Agent backends     | Route matrix for native CLI, JSON stream, MCP, ACP, HTTP API, OpenAI-compatible, and bridge routes                                                |
-| Operation policy   | `open`, `confirm`, and `locked` profiles with effect/risk scopes, local deny rules, `--yes`, and persisted approval memory                        |
-| Evidence           | Run traces with probe/replay/compare, browser session leases with tab/auth posture, render-aware evidence, movement checks, and stale-ref details |
-| Output             | v2 `AgentEnvelope` in Markdown, JSON, YAML, CSV, or compact format                                                                                |
-| Repair             | Structured errors with `adapter_path`, failing `step`, retryability, suggestions, and alternatives                                                |
+| Surface            | What you get                                                                                                                                             |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Websites and APIs  | Declarative adapters for public, cookie, header, and browser-intercept workflows                                                                         |
+| Browser automation | CDP steps for navigate, click, type, intercept, snapshot, extract, wait, and related browser work                                                        |
+| Desktop and macOS  | System commands, app adapters, screenshots, clipboard, calendar, brightness, and local tools                                                             |
+| External CLIs      | 58 registered pass-through bridges with install/status discovery                                                                                         |
+| Agent backends     | Route matrix for native CLI, JSON stream, MCP, ACP, HTTP API, OpenAI-compatible, and bridge routes                                                       |
+| Operation policy   | `open`, `confirm`, and `locked` profiles with effect/risk scopes, local deny rules, `--yes`, and persisted approval memory                               |
+| Evidence           | Run traces with probe/replay/compare scores, browser session leases with tab/auth posture, render-aware evidence, movement checks, and stale-ref details |
+| Output             | v2 `AgentEnvelope` in Markdown, JSON, YAML, CSV, or compact format                                                                                       |
+| Repair             | Structured errors with `adapter_path`, failing `step`, retryability, suggestions, and alternatives                                                       |
 
 ## For Agents
 
@@ -164,6 +164,7 @@ unicli runs show <run_id> -f json
 unicli runs probe <run_id> -f json
 unicli runs replay <run_id> --permission-profile confirm --yes -f json
 unicli runs compare <run_id> <replay_run_id> -f json
+unicli runs compare <run_id> <replay_run_id> --min-score 1 -f json
 unicli --permission-profile locked --yes --remember-approval word set-font "Inter"
 unicli approvals list -f json
 unicli approvals revoke <approval_key> -f json

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -28,7 +28,7 @@
 </p>
 
 <p align="center">
-  <sub><!-- STATS:site_count -->235<!-- /STATS --> 个站点 · <!-- STATS:command_count -->1448<!-- /STATS --> 条命令 · <!-- STATS:pipeline_step_count -->59<!-- /STATS --> 个 pipeline step · <!-- STATS:test_count -->7567<!-- /STATS --> 个测试</sub>
+  <sub><!-- STATS:site_count -->235<!-- /STATS --> 个站点 · <!-- STATS:command_count -->1448<!-- /STATS --> 条命令 · <!-- STATS:pipeline_step_count -->59<!-- /STATS --> 个 pipeline step · <!-- STATS:test_count -->7569<!-- /STATS --> 个测试</sub>
 </p>
 
 <p align="center">
@@ -131,17 +131,17 @@ Prefer native CLI / JSON stream / MCP for agent runtimes. Use ACP as an editor c
 
 Uni-CLI 位于 Agent 应用之下，把软件表面收敛成 Agent 能发现、能执行、能记录、能修的命令。
 
-| 表面         | 能力                                                                                                                      |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------- |
-| 网站和 API   | public、cookie、header、browser-intercept 等 adapter                                                                      |
-| 浏览器自动化 | CDP 的 navigate、click、type、intercept、snapshot、extract、wait 等步骤                                                   |
-| 桌面和 macOS | 系统命令、App adapter、截图、剪贴板、日历、亮度、本地工具                                                                 |
-| 外部 CLI     | 58 个已登记的 passthrough bridge，支持安装和状态发现                                                                      |
-| Agent 后端   | native CLI、JSON stream、MCP、ACP、HTTP API、OpenAI-compatible、bridge 路由矩阵                                           |
-| 操作策略     | `open`、`confirm`、`locked` profile，暴露 effect/risk scope、本地 deny 规则、`--yes` 和持久审批记忆                       |
-| 执行证据     | 可 probe/replay/compare 的 run trace、带 tab/auth 姿态的浏览器 session lease、render-aware 证据、移动检测、stale-ref 细节 |
-| 输出         | v2 `AgentEnvelope`，支持 Markdown、JSON、YAML、CSV、compact                                                               |
-| 修复         | 错误里带 `adapter_path`、失败 `step`、是否可重试、修复建议和替代命令                                                      |
+| 表面         | 能力                                                                                                                          |
+| ------------ | ----------------------------------------------------------------------------------------------------------------------------- |
+| 网站和 API   | public、cookie、header、browser-intercept 等 adapter                                                                          |
+| 浏览器自动化 | CDP 的 navigate、click、type、intercept、snapshot、extract、wait 等步骤                                                       |
+| 桌面和 macOS | 系统命令、App adapter、截图、剪贴板、日历、亮度、本地工具                                                                     |
+| 外部 CLI     | 58 个已登记的 passthrough bridge，支持安装和状态发现                                                                          |
+| Agent 后端   | native CLI、JSON stream、MCP、ACP、HTTP API、OpenAI-compatible、bridge 路由矩阵                                               |
+| 操作策略     | `open`、`confirm`、`locked` profile，暴露 effect/risk scope、本地 deny 规则、`--yes` 和持久审批记忆                           |
+| 执行证据     | 可 probe/replay/compare 打分的 run trace、带 tab/auth 姿态的浏览器 session lease、render-aware 证据、移动检测、stale-ref 细节 |
+| 输出         | v2 `AgentEnvelope`，支持 Markdown、JSON、YAML、CSV、compact                                                                   |
+| 修复         | 错误里带 `adapter_path`、失败 `step`、是否可重试、修复建议和替代命令                                                          |
 
 ## 给 Agent 的入口
 
@@ -164,6 +164,7 @@ unicli runs show <run_id> -f json
 unicli runs probe <run_id> -f json
 unicli runs replay <run_id> --permission-profile confirm --yes -f json
 unicli runs compare <run_id> <replay_run_id> -f json
+unicli runs compare <run_id> <replay_run_id> --min-score 1 -f json
 unicli --permission-profile locked --yes --remember-approval word set-font "Inter"
 unicli approvals list -f json
 unicli approvals revoke <approval_key> -f json

--- a/contributing/COPY.md
+++ b/contributing/COPY.md
@@ -2,7 +2,7 @@
 
 > Current version: v0.217.0 — Apollo · Lovell.
 >
-> Current scale: <!-- STATS:site_count -->235<!-- /STATS --> sites, <!-- STATS:command_count -->1448<!-- /STATS --> commands, <!-- STATS:adapter_count_total -->1039<!-- /STATS --> adapters (<!-- STATS:adapter_count_yaml -->917<!-- /STATS --> YAML + <!-- STATS:adapter_count_ts -->122<!-- /STATS --> TS), <!-- STATS:test_count -->7567<!-- /STATS --> tests.
+> Current scale: <!-- STATS:site_count -->235<!-- /STATS --> sites, <!-- STATS:command_count -->1448<!-- /STATS --> commands, <!-- STATS:adapter_count_total -->1039<!-- /STATS --> adapters (<!-- STATS:adapter_count_yaml -->917<!-- /STATS --> YAML + <!-- STATS:adapter_count_ts -->122<!-- /STATS --> TS), <!-- STATS:test_count -->7569<!-- /STATS --> tests.
 
 This file keeps docs and user-facing copy consistent. Public pages should expose
 install, command, output, and repair facts with the fewest words needed.

--- a/src/commands/runs.ts
+++ b/src/commands/runs.ts
@@ -56,6 +56,7 @@ interface RunsReplayOptions {
 
 interface RunsCompareOptions {
   root?: string;
+  minScore?: string;
 }
 
 function fmt(program: Command): OutputFormat {
@@ -90,6 +91,13 @@ function runStoreAgentErrorCode(error: RunStoreError): string {
   return error.code === "invalid_run_id" || error.code === "malformed_jsonl"
     ? "invalid_input"
     : "internal_error";
+}
+
+function scoreThreshold(value: string | undefined): number | undefined {
+  if (value === undefined) return undefined;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return undefined;
+  return parsed;
 }
 
 export function registerRunsCommand(program: Command): void {
@@ -214,6 +222,10 @@ export function registerRunsCommand(program: Command): void {
     .command("compare <left_run_id> <right_run_id>")
     .description("Compare two recorded run traces for replay/eval review")
     .option("--root <path>", "Override run trace root")
+    .option(
+      "--min-score <0-1>",
+      "Set a minimum behavior score and exit non-zero when it is missed",
+    )
     .action(
       async (
         leftRunId: string,
@@ -222,6 +234,16 @@ export function registerRunsCommand(program: Command): void {
       ) => {
         const startedAt = Date.now();
         const store = createRunStore({ rootDir: opts.root });
+        const minScore = scoreThreshold(opts.minScore);
+        if (opts.minScore !== undefined && minScore === undefined) {
+          printRunError(program, "runs.compare", startedAt, {
+            code: "invalid_input",
+            message: "--min-score must be a number between 0 and 1",
+            suggestion: "use `--min-score 1` for exact replay gates",
+            retryable: false,
+          });
+          return;
+        }
         const leftEvents = await readRunEvents(store, leftRunId);
         if (leftEvents.length === 0) {
           printRunError(program, "runs.compare", startedAt, {
@@ -254,6 +276,12 @@ export function registerRunsCommand(program: Command): void {
             makeCtx("runs.compare", startedAt),
           ),
         );
+        if (
+          minScore !== undefined &&
+          comparison.score.behavior.score < minScore
+        ) {
+          process.exitCode = 1;
+        }
       },
     );
 

--- a/src/engine/session/compare.ts
+++ b/src/engine/session/compare.ts
@@ -55,12 +55,27 @@ export interface RunComparisonCounts {
   unknown: number;
 }
 
+export interface RunComparisonScoreBucket extends RunComparisonCounts {
+  total: number;
+  score: number;
+}
+
+export interface RunComparisonScore {
+  passed: boolean;
+  overall: number;
+  behavior: RunComparisonScoreBucket;
+  context: RunComparisonScoreBucket;
+  failed_behavior_checks: string[];
+  unknown_behavior_checks: string[];
+}
+
 export interface RunComparison {
   left_run_id: RunId;
   right_run_id: RunId;
   status: RunComparisonStatus;
   behavior: RunComparisonCounts;
   context: RunComparisonCounts;
+  score: RunComparisonScore;
   checks: RunComparisonCheck[];
   left: RunComparableSummary;
   right: RunComparableSummary;
@@ -328,6 +343,31 @@ function countChecks(
   };
 }
 
+function roundedScore(value: number): number {
+  return Number(value.toFixed(4));
+}
+
+function scoreChecks(
+  checks: RunComparisonCheck[],
+  impact?: RunComparisonImpact,
+): RunComparisonScoreBucket {
+  const scoped =
+    impact === undefined
+      ? checks
+      : checks.filter((check) => check.impact === impact);
+  const counts = {
+    match: scoped.filter((check) => check.status === "match").length,
+    diverged: scoped.filter((check) => check.status === "diverged").length,
+    unknown: scoped.filter((check) => check.status === "unknown").length,
+  };
+  const total = scoped.length;
+  return {
+    ...counts,
+    total,
+    score: total === 0 ? 1 : roundedScore(counts.match / total),
+  };
+}
+
 function overallStatus(checks: RunComparisonCheck[]): RunComparisonStatus {
   const behavior = checks.filter((check) => check.impact === "behavior");
   if (behavior.some((check) => check.status === "diverged")) {
@@ -337,6 +377,28 @@ function overallStatus(checks: RunComparisonCheck[]): RunComparisonStatus {
     return "unknown";
   }
   return "match";
+}
+
+function comparisonScore(
+  checks: RunComparisonCheck[],
+  status: RunComparisonStatus,
+): RunComparisonScore {
+  return {
+    passed: status === "match",
+    overall: scoreChecks(checks).score,
+    behavior: scoreChecks(checks, "behavior"),
+    context: scoreChecks(checks, "context"),
+    failed_behavior_checks: checks
+      .filter(
+        (check) => check.impact === "behavior" && check.status === "diverged",
+      )
+      .map((check) => check.name),
+    unknown_behavior_checks: checks
+      .filter(
+        (check) => check.impact === "behavior" && check.status === "unknown",
+      )
+      .map((check) => check.name),
+  };
 }
 
 export function compareRunEvents(
@@ -450,13 +512,15 @@ export function compareRunEvents(
       { missingMeansMatch: true },
     ),
   ];
+  const status = overallStatus(checks);
 
   return {
     left_run_id: options.leftRunId,
     right_run_id: options.rightRunId,
-    status: overallStatus(checks),
+    status,
     behavior: countChecks(checks, "behavior"),
     context: countChecks(checks, "context"),
+    score: comparisonScore(checks, status),
     checks,
     left,
     right,

--- a/stats.json
+++ b/stats.json
@@ -4,7 +4,7 @@
   "adapter_count_total": 1039,
   "site_count": 235,
   "command_count": 1448,
-  "test_count": 7567,
+  "test_count": 7569,
   "pipeline_step_count": 59,
   "transport_count": 3,
   "app_transport_count": 7,

--- a/tests/unit/session-compare.test.ts
+++ b/tests/unit/session-compare.test.ts
@@ -98,6 +98,28 @@ function deniedTrace(
 }
 
 describe("run trace comparison", () => {
+  it("scores matching behavior as a reproducible full match", () => {
+    const comparison = compareRunEvents(
+      deniedTrace("run-left", "deny-old-domain", ["domains"]),
+      deniedTrace("run-right", "deny-old-domain", ["domains"]),
+      { leftRunId: "run-left", rightRunId: "run-right" },
+    );
+
+    expect(comparison.status).toBe("match");
+    expect(comparison.score).toMatchObject({
+      passed: true,
+      behavior: {
+        score: 1,
+        diverged: 0,
+        unknown: 0,
+      },
+      failed_behavior_checks: [],
+      unknown_behavior_checks: [],
+    });
+    expect(comparison.score.behavior.total).toBeGreaterThan(0);
+    expect(comparison.score.overall).toBe(1);
+  });
+
   it("compares runtime permission deny decisions without raw resources", () => {
     const comparison = compareRunEvents(
       deniedTrace("run-left", "deny-old-domain", ["domains"]),
@@ -106,6 +128,14 @@ describe("run trace comparison", () => {
     );
 
     expect(comparison.status).toBe("diverged");
+    expect(comparison.score.passed).toBe(false);
+    expect(comparison.score.behavior.score).toBeLessThan(1);
+    expect(comparison.score.failed_behavior_checks).toEqual(
+      expect.arrayContaining([
+        "runtime_permission_rule",
+        "runtime_permission_resource_buckets",
+      ]),
+    );
     expect(comparison.left.result).toMatchObject({
       error_code: "permission_denied",
       runtime_permission_denied: {

--- a/tests/unit/session-runs-command.test.ts
+++ b/tests/unit/session-runs-command.test.ts
@@ -941,6 +941,52 @@ describe("unicli runs command", () => {
     );
   });
 
+  it("can fail CI when compare behavior score is below a threshold", async () => {
+    const rootDir = join(tmp, "runs");
+    const runId = await writeReplayableRun(rootDir);
+    const driftedRunId = await writeDivergedRun(rootDir);
+
+    const cap = captureConsole();
+    try {
+      const program = createProgram();
+      await program.parseAsync(
+        [
+          "-f",
+          "json",
+          "runs",
+          "compare",
+          runId,
+          driftedRunId,
+          "--root",
+          rootDir,
+          "--min-score",
+          "1",
+        ],
+        { from: "user" },
+      );
+    } finally {
+      cap.restore();
+    }
+
+    const env = JSON.parse(cap.getStdout().trim()) as {
+      ok: boolean;
+      data: {
+        status: string;
+        score: {
+          passed: boolean;
+          behavior: { score: number };
+          failed_behavior_checks: string[];
+        };
+      };
+    };
+    expect(env.ok).toBe(true);
+    expect(env.data.status).toBe("diverged");
+    expect(env.data.score.passed).toBe(false);
+    expect(env.data.score.behavior.score).toBeLessThan(1);
+    expect(env.data.score.failed_behavior_checks.length).toBeGreaterThan(0);
+    expect(process.exitCode).toBe(1);
+  });
+
   it("rejects compare when either trace is missing", async () => {
     const rootDir = join(tmp, "runs");
     const runId = await writeReplayableRun(rootDir);


### PR DESCRIPTION
## Summary
- add stable numeric score fields to run trace comparisons
- add `runs compare --min-score` so replay gates can fail CI while still emitting the full comparison envelope
- document the compare score entrypoint and refresh generated test counts

## Checks
- `pnpm exec vitest run --project unit tests/unit/session-compare.test.ts tests/unit/session-runs-command.test.ts`
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `pnpm stats:check`
- `pnpm verify:changesets`
- pre-push `pnpm verify:clean`