### PR TITLE
feat: record run environment snapshots

### DIFF
--- a/.changeset/run-environment-snapshot.md
+++ b/.changeset/run-environment-snapshot.md
@@ -1,0 +1,5 @@
+---
+"@zenalexa/unicli": minor
+---
+
+Record public environment snapshot events in run traces and compare them as reproducibility context.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 </p>
 
 <p align="center">
-  <sub><!-- STATS:site_count -->235<!-- /STATS --> sites · <!-- STATS:command_count -->1448<!-- /STATS --> commands · <!-- STATS:pipeline_step_count -->59<!-- /STATS --> pipeline steps · <!-- STATS:test_count -->7569<!-- /STATS --> tests</sub>
+  <sub><!-- STATS:site_count -->235<!-- /STATS --> sites · <!-- STATS:command_count -->1448<!-- /STATS --> commands · <!-- STATS:pipeline_step_count -->59<!-- /STATS --> pipeline steps · <!-- STATS:test_count -->7573<!-- /STATS --> tests</sub>
 </p>
 
 <p align="center">
@@ -131,17 +131,17 @@ Prefer native CLI / JSON stream / MCP for agent runtimes. Use ACP as an editor c
 
 Uni-CLI sits under agent applications and turns software surfaces into commands that agents can discover, execute, record, and repair.
 
-| Surface            | What you get                                                                                                                                             |
-| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Websites and APIs  | Declarative adapters for public, cookie, header, and browser-intercept workflows                                                                         |
-| Browser automation | CDP steps for navigate, click, type, intercept, snapshot, extract, wait, and related browser work                                                        |
-| Desktop and macOS  | System commands, app adapters, screenshots, clipboard, calendar, brightness, and local tools                                                             |
-| External CLIs      | 58 registered pass-through bridges with install/status discovery                                                                                         |
-| Agent backends     | Route matrix for native CLI, JSON stream, MCP, ACP, HTTP API, OpenAI-compatible, and bridge routes                                                       |
-| Operation policy   | `open`, `confirm`, and `locked` profiles with effect/risk scopes, local deny rules, `--yes`, and persisted approval memory                               |
-| Evidence           | Run traces with probe/replay/compare scores, browser session leases with tab/auth posture, render-aware evidence, movement checks, and stale-ref details |
-| Output             | v2 `AgentEnvelope` in Markdown, JSON, YAML, CSV, or compact format                                                                                       |
-| Repair             | Structured errors with `adapter_path`, failing `step`, retryability, suggestions, and alternatives                                                       |
+| Surface            | What you get                                                                                                                                                                    |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Websites and APIs  | Declarative adapters for public, cookie, header, and browser-intercept workflows                                                                                                |
+| Browser automation | CDP steps for navigate, click, type, intercept, snapshot, extract, wait, and related browser work                                                                               |
+| Desktop and macOS  | System commands, app adapters, screenshots, clipboard, calendar, brightness, and local tools                                                                                    |
+| External CLIs      | 58 registered pass-through bridges with install/status discovery                                                                                                                |
+| Agent backends     | Route matrix for native CLI, JSON stream, MCP, ACP, HTTP API, OpenAI-compatible, and bridge routes                                                                              |
+| Operation policy   | `open`, `confirm`, and `locked` profiles with effect/risk scopes, local deny rules, `--yes`, and persisted approval memory                                                      |
+| Evidence           | Run traces with environment snapshots, probe/replay/compare scores, browser session leases with tab/auth posture, render-aware evidence, movement checks, and stale-ref details |
+| Output             | v2 `AgentEnvelope` in Markdown, JSON, YAML, CSV, or compact format                                                                                                              |
+| Repair             | Structured errors with `adapter_path`, failing `step`, retryability, suggestions, and alternatives                                                                              |
 
 ## For Agents
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -28,7 +28,7 @@
 </p>
 
 <p align="center">
-  <sub><!-- STATS:site_count -->235<!-- /STATS --> 个站点 · <!-- STATS:command_count -->1448<!-- /STATS --> 条命令 · <!-- STATS:pipeline_step_count -->59<!-- /STATS --> 个 pipeline step · <!-- STATS:test_count -->7569<!-- /STATS --> 个测试</sub>
+  <sub><!-- STATS:site_count -->235<!-- /STATS --> 个站点 · <!-- STATS:command_count -->1448<!-- /STATS --> 条命令 · <!-- STATS:pipeline_step_count -->59<!-- /STATS --> 个 pipeline step · <!-- STATS:test_count -->7573<!-- /STATS --> 个测试</sub>
 </p>
 
 <p align="center">
@@ -131,17 +131,17 @@ Prefer native CLI / JSON stream / MCP for agent runtimes. Use ACP as an editor c
 
 Uni-CLI 位于 Agent 应用之下，把软件表面收敛成 Agent 能发现、能执行、能记录、能修的命令。
 
-| 表面         | 能力                                                                                                                          |
-| ------------ | ----------------------------------------------------------------------------------------------------------------------------- |
-| 网站和 API   | public、cookie、header、browser-intercept 等 adapter                                                                          |
-| 浏览器自动化 | CDP 的 navigate、click、type、intercept、snapshot、extract、wait 等步骤                                                       |
-| 桌面和 macOS | 系统命令、App adapter、截图、剪贴板、日历、亮度、本地工具                                                                     |
-| 外部 CLI     | 58 个已登记的 passthrough bridge，支持安装和状态发现                                                                          |
-| Agent 后端   | native CLI、JSON stream、MCP、ACP、HTTP API、OpenAI-compatible、bridge 路由矩阵                                               |
-| 操作策略     | `open`、`confirm`、`locked` profile，暴露 effect/risk scope、本地 deny 规则、`--yes` 和持久审批记忆                           |
-| 执行证据     | 可 probe/replay/compare 打分的 run trace、带 tab/auth 姿态的浏览器 session lease、render-aware 证据、移动检测、stale-ref 细节 |
-| 输出         | v2 `AgentEnvelope`，支持 Markdown、JSON、YAML、CSV、compact                                                                   |
-| 修复         | 错误里带 `adapter_path`、失败 `step`、是否可重试、修复建议和替代命令                                                          |
+| 表面         | 能力                                                                                                                                                 |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 网站和 API   | public、cookie、header、browser-intercept 等 adapter                                                                                                 |
+| 浏览器自动化 | CDP 的 navigate、click、type、intercept、snapshot、extract、wait 等步骤                                                                              |
+| 桌面和 macOS | 系统命令、App adapter、截图、剪贴板、日历、亮度、本地工具                                                                                            |
+| 外部 CLI     | 58 个已登记的 passthrough bridge，支持安装和状态发现                                                                                                 |
+| Agent 后端   | native CLI、JSON stream、MCP、ACP、HTTP API、OpenAI-compatible、bridge 路由矩阵                                                                      |
+| 操作策略     | `open`、`confirm`、`locked` profile，暴露 effect/risk scope、本地 deny 规则、`--yes` 和持久审批记忆                                                  |
+| 执行证据     | run trace 会记录环境快照，也能 probe/replay/compare 打分；浏览器 session lease 带 tab/auth 姿态，还支持 render-aware 证据、移动检测和 stale-ref 细节 |
+| 输出         | v2 `AgentEnvelope`，支持 Markdown、JSON、YAML、CSV、compact                                                                                          |
+| 修复         | 错误里带 `adapter_path`、失败 `step`、是否可重试、修复建议和替代命令                                                                                 |
 
 ## 给 Agent 的入口
 

--- a/contributing/COPY.md
+++ b/contributing/COPY.md
@@ -2,7 +2,7 @@
 
 > Current version: v0.217.0 — Apollo · Lovell.
 >
-> Current scale: <!-- STATS:site_count -->235<!-- /STATS --> sites, <!-- STATS:command_count -->1448<!-- /STATS --> commands, <!-- STATS:adapter_count_total -->1039<!-- /STATS --> adapters (<!-- STATS:adapter_count_yaml -->917<!-- /STATS --> YAML + <!-- STATS:adapter_count_ts -->122<!-- /STATS --> TS), <!-- STATS:test_count -->7569<!-- /STATS --> tests.
+> Current scale: <!-- STATS:site_count -->235<!-- /STATS --> sites, <!-- STATS:command_count -->1448<!-- /STATS --> commands, <!-- STATS:adapter_count_total -->1039<!-- /STATS --> adapters (<!-- STATS:adapter_count_yaml -->917<!-- /STATS --> YAML + <!-- STATS:adapter_count_ts -->122<!-- /STATS --> TS), <!-- STATS:test_count -->7573<!-- /STATS --> tests.
 
 This file keeps docs and user-facing copy consistent. Public pages should expose
 install, command, output, and repair facts with the fewest words needed.

--- a/src/engine/browser/action-evidence.ts
+++ b/src/engine/browser/action-evidence.ts
@@ -10,6 +10,7 @@ import {
   type RunStore,
 } from "../session/store.js";
 import {
+  createEnvironmentSnapshotEvent,
   createEvidenceCapturedEvent,
   createPermissionEvaluatedEvent,
   createRunCompletedEvent,
@@ -24,6 +25,7 @@ import {
   type RunTraceMetadata,
   type TraceId,
 } from "../session/events.js";
+import { environmentSnapshotData } from "../session/environment.js";
 import { isRunRecordingEnabled } from "../session/run-loop.js";
 import { userHome } from "../user-home.js";
 import {
@@ -121,6 +123,11 @@ export async function withBrowserActionEvidence<T>(
     store,
     [
       createRunStartedEvent(metadata, sequence),
+      createEnvironmentSnapshotEvent(
+        metadata,
+        sequence,
+        environmentSnapshotData(metadata),
+      ),
       createToolCallStartedEvent(metadata, sequence, {
         action: options.action,
         workspace: options.workspace,

--- a/src/engine/session/compare.ts
+++ b/src/engine/session/compare.ts
@@ -33,6 +33,18 @@ export interface RunComparableEvidence {
   by_type: Record<string, number>;
 }
 
+export interface RunComparableEnvironment {
+  unicli_version?: string;
+  node_version?: string;
+  platform?: string;
+  arch?: string;
+  ci?: boolean;
+  permission_profile?: string;
+  transport_surface?: string;
+  target_surface?: string;
+  pipeline_steps?: number;
+}
+
 export interface RunComparableSummary {
   run_id: RunId;
   command?: string;
@@ -45,6 +57,7 @@ export interface RunComparableSummary {
   browser_tab_id?: number;
   browser_window_id?: number;
   browser_auth_state?: string;
+  environment?: RunComparableEnvironment;
   result: RunComparableResult;
   evidence: RunComparableEvidence;
 }
@@ -90,6 +103,7 @@ function metadataFromEvents(events: RunEvent[]): RunTraceMetadata | undefined {
 }
 
 interface ComparableEventScan {
+  environment?: RunEvent;
   terminal?: RunEvent;
   toolTerminal?: RunEvent;
   resultEnvelope?: RunEvent;
@@ -120,6 +134,9 @@ function scanComparableEvents(events: RunEvent[]): ComparableEventScan {
     ) {
       scan.resultEnvelope = event;
     }
+    if (!scan.environment && event.name === "environment.snapshot") {
+      scan.environment = event;
+    }
     if (
       !scan.runtimePermissionDenied &&
       event.name === "permission.runtime_denied"
@@ -130,6 +147,7 @@ function scanComparableEvents(events: RunEvent[]): ComparableEventScan {
       scan.terminal &&
       scan.toolTerminal &&
       scan.resultEnvelope &&
+      scan.environment &&
       (scan.runtimePermissionDenied ||
         errorCodeFromEvent(scan.toolTerminal) !== "permission_denied")
     ) {
@@ -214,6 +232,33 @@ function runtimePermissionDeniedFromEvent(
   };
 }
 
+function environmentFromEvent(
+  event?: RunEvent,
+): RunComparableEnvironment | undefined {
+  if (!event) return undefined;
+  const unicliVersion = stringField("unicli_version", event);
+  const nodeVersion = stringField("node_version", event);
+  const platform = stringField("platform", event);
+  const arch = stringField("arch", event);
+  const ci = booleanField("ci", event);
+  const permissionProfile = stringField("permission_profile", event);
+  const transportSurface = stringField("transport_surface", event);
+  const targetSurface = stringField("target_surface", event);
+  const pipelineSteps = numberField("pipeline_steps", event);
+  const environment: RunComparableEnvironment = {
+    ...(unicliVersion ? { unicli_version: unicliVersion } : {}),
+    ...(nodeVersion ? { node_version: nodeVersion } : {}),
+    ...(platform ? { platform } : {}),
+    ...(arch ? { arch } : {}),
+    ...(ci !== undefined ? { ci } : {}),
+    ...(permissionProfile ? { permission_profile: permissionProfile } : {}),
+    ...(transportSurface ? { transport_surface: transportSurface } : {}),
+    ...(targetSurface ? { target_surface: targetSurface } : {}),
+    ...(pipelineSteps !== undefined ? { pipeline_steps: pipelineSteps } : {}),
+  };
+  return Object.keys(environment).length > 0 ? environment : undefined;
+}
+
 function evidenceSummary(events: RunEvent[]): RunComparableEvidence {
   const byType: Record<string, number> = {};
   for (const event of events) {
@@ -239,6 +284,7 @@ export function summarizeComparableRun(
   const scan = scanComparableEvents(events);
   const { terminal, toolTerminal, resultEnvelope, runtimePermissionDenied } =
     scan;
+  const environment = environmentFromEvent(scan.environment);
   const exitCode = numberField(
     "exit_code",
     terminal,
@@ -285,6 +331,7 @@ export function summarizeComparableRun(
     ...(summary.browser_auth_state
       ? { browser_auth_state: summary.browser_auth_state }
       : {}),
+    ...(environment ? { environment } : {}),
     result: {
       ...(exitCode !== undefined ? { exit_code: exitCode } : {}),
       ...(resultCount !== undefined ? { result_count: resultCount } : {}),
@@ -310,16 +357,26 @@ function compareScalar(
   left: unknown,
   right: unknown,
   impact: RunComparisonImpact,
-  options: { missingMeansMatch?: boolean } = {},
+  options: {
+    missingMeansMatch?: boolean;
+    missingEitherMeansMatch?: boolean;
+  } = {},
 ): RunComparisonCheck {
   if (left === undefined && right === undefined) {
     return {
       name,
       impact,
-      status: options.missingMeansMatch === true ? "match" : "unknown",
+      status:
+        options.missingMeansMatch === true ||
+        options.missingEitherMeansMatch === true
+          ? "match"
+          : "unknown",
     };
   }
   if (left === undefined || right === undefined) {
+    if (options.missingEitherMeansMatch === true) {
+      return { name, impact, status: "match", left, right };
+    }
     return { name, impact, status: "unknown", left, right };
   }
   return {
@@ -482,6 +539,69 @@ export function compareRunEvents(
       left.target_surface,
       right.target_surface,
       "context",
+    ),
+    compareScalar(
+      "environment_unicli_version",
+      left.environment?.unicli_version,
+      right.environment?.unicli_version,
+      "context",
+      { missingEitherMeansMatch: true },
+    ),
+    compareScalar(
+      "environment_node_version",
+      left.environment?.node_version,
+      right.environment?.node_version,
+      "context",
+      { missingEitherMeansMatch: true },
+    ),
+    compareScalar(
+      "environment_platform",
+      left.environment?.platform,
+      right.environment?.platform,
+      "context",
+      { missingEitherMeansMatch: true },
+    ),
+    compareScalar(
+      "environment_arch",
+      left.environment?.arch,
+      right.environment?.arch,
+      "context",
+      { missingEitherMeansMatch: true },
+    ),
+    compareScalar(
+      "environment_ci",
+      left.environment?.ci,
+      right.environment?.ci,
+      "context",
+      { missingEitherMeansMatch: true },
+    ),
+    compareScalar(
+      "environment_permission_profile",
+      left.environment?.permission_profile,
+      right.environment?.permission_profile,
+      "context",
+      { missingEitherMeansMatch: true },
+    ),
+    compareScalar(
+      "environment_transport_surface",
+      left.environment?.transport_surface,
+      right.environment?.transport_surface,
+      "context",
+      { missingEitherMeansMatch: true },
+    ),
+    compareScalar(
+      "environment_target_surface",
+      left.environment?.target_surface,
+      right.environment?.target_surface,
+      "context",
+      { missingEitherMeansMatch: true },
+    ),
+    compareScalar(
+      "environment_pipeline_steps",
+      left.environment?.pipeline_steps,
+      right.environment?.pipeline_steps,
+      "context",
+      { missingEitherMeansMatch: true },
     ),
     compareScalar(
       "browser_target_kind",

--- a/src/engine/session/environment.ts
+++ b/src/engine/session/environment.ts
@@ -1,0 +1,31 @@
+import { VERSION } from "../../constants.js";
+import type { RunTraceMetadata } from "./types.js";
+
+function truthyEnvFlag(value: string | undefined): boolean {
+  if (value === undefined) return false;
+  const normalized = value.trim().toLowerCase();
+  return !["", "0", "false", "no", "off"].includes(normalized);
+}
+
+export function isCiEnvironment(): boolean {
+  return (
+    truthyEnvFlag(process.env.CI) || truthyEnvFlag(process.env.GITHUB_ACTIONS)
+  );
+}
+
+export function environmentSnapshotData(
+  metadata: RunTraceMetadata,
+): Record<string, unknown> {
+  return {
+    schema_version: "1",
+    unicli_version: VERSION,
+    node_version: process.version,
+    platform: process.platform,
+    arch: process.arch,
+    ci: isCiEnvironment(),
+    permission_profile: metadata.permission_profile,
+    transport_surface: metadata.transport_surface,
+    target_surface: metadata.target_surface,
+    pipeline_steps: metadata.pipeline_steps,
+  };
+}

--- a/src/engine/session/events.ts
+++ b/src/engine/session/events.ts
@@ -64,6 +64,17 @@ export function createRunStartedEvent(
   return createEvent("run.started", metadata, sequence, options);
 }
 
+export function createEnvironmentSnapshotEvent(
+  metadata: RunTraceMetadata,
+  sequence: RunEventSequence,
+  data: Record<string, unknown>,
+): RunEvent {
+  return createEvent("environment.snapshot", metadata, sequence, {
+    visibility: "public",
+    data,
+  });
+}
+
 export function createToolCallStartedEvent(
   metadata: RunTraceMetadata,
   sequence: RunEventSequence,

--- a/src/engine/session/run-loop.ts
+++ b/src/engine/session/run-loop.ts
@@ -15,6 +15,7 @@ import {
   RunStoreError,
 } from "./store.js";
 import {
+  createEnvironmentSnapshotEvent,
   createPermissionEvaluatedEvent,
   createEvidenceCapturedEvent,
   createRuntimePermissionDeniedEvent,
@@ -30,6 +31,7 @@ import {
   type RunTraceMetadata,
 } from "./events.js";
 import { hashRunArgs } from "./args.js";
+import { environmentSnapshotData } from "./environment.js";
 
 export interface RunRecordingOptions {
   enabled?: boolean;
@@ -259,6 +261,11 @@ export async function executeWithRunRecording(
     store,
     [
       createRunStartedEvent(metadata, sequence),
+      createEnvironmentSnapshotEvent(
+        metadata,
+        sequence,
+        environmentSnapshotData(metadata),
+      ),
       {
         ...createToolCallStartedEvent(metadata, sequence),
         secret: replaySecretForInvocation(inv, metadata),

--- a/src/engine/session/types.ts
+++ b/src/engine/session/types.ts
@@ -7,6 +7,7 @@ export type TraceId = string;
 
 export type RunEventName =
   | "run.started"
+  | "environment.snapshot"
   | "tool.call.started"
   | "permission.evaluated"
   | "permission.runtime_denied"

--- a/stats.json
+++ b/stats.json
@@ -4,7 +4,7 @@
   "adapter_count_total": 1039,
   "site_count": 235,
   "command_count": 1448,
-  "test_count": 7569,
+  "test_count": 7573,
   "pipeline_step_count": 59,
   "transport_count": 3,
   "app_transport_count": 7,

--- a/tests/unit/commands/browser.test.ts
+++ b/tests/unit/commands/browser.test.ts
@@ -280,6 +280,7 @@ describe("unicli browser operator surface", () => {
     );
     expect(events.map((event) => event.name)).toEqual([
       "run.started",
+      "environment.snapshot",
       "tool.call.started",
       "permission.evaluated",
       "evidence.captured",
@@ -287,6 +288,18 @@ describe("unicli browser operator surface", () => {
       "tool.call.completed",
       "run.completed",
     ]);
+    expect(events[1]).toMatchObject({
+      visibility: "public",
+      data: {
+        schema_version: "1",
+        transport_surface: "cli",
+        target_surface: "web",
+        permission_profile: "open",
+        pipeline_steps: 0,
+      },
+    });
+    expect(events[1]).not.toHaveProperty("internal");
+    expect(events[1]).not.toHaveProperty("secret");
     const expectedLease = createBrowserSessionLease({
       namespace: "browser",
       workspace: "browser:default",
@@ -515,6 +528,7 @@ describe("unicli browser operator surface", () => {
     );
     expect(events.map((event) => event.name)).toEqual([
       "run.started",
+      "environment.snapshot",
       "tool.call.started",
       "permission.evaluated",
       "evidence.captured",
@@ -591,6 +605,7 @@ describe("unicli browser operator surface", () => {
     );
     expect(events.map((event) => event.name)).toEqual([
       "run.started",
+      "environment.snapshot",
       "tool.call.started",
       "permission.evaluated",
       "evidence.captured",

--- a/tests/unit/session-compare.test.ts
+++ b/tests/unit/session-compare.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  createEnvironmentSnapshotEvent,
   createEvidenceCapturedEvent,
   createPermissionEvaluatedEvent,
   createRunEventSequence,
@@ -55,6 +56,18 @@ function deniedTrace(
 
   return [
     createRunStartedEvent(metadata, sequence),
+    createEnvironmentSnapshotEvent(metadata, sequence, {
+      schema_version: "1",
+      unicli_version: "0.217.0",
+      node_version: "v24.0.0",
+      platform: "darwin",
+      arch: "arm64",
+      ci: false,
+      permission_profile: metadata.permission_profile,
+      transport_surface: metadata.transport_surface,
+      target_surface: metadata.target_surface,
+      pipeline_steps: metadata.pipeline_steps,
+    }),
     createToolCallStartedEvent(metadata, sequence),
     createPermissionEvaluatedEvent(metadata, sequence, {
       profile: "open",
@@ -166,5 +179,76 @@ describe("run trace comparison", () => {
       ]),
     );
     expect(JSON.stringify(comparison)).not.toContain("blocked.example");
+  });
+
+  it("compares environment snapshots as reproducibility context", () => {
+    const left = deniedTrace("run-left", "deny-old-domain", ["domains"]);
+    const right = deniedTrace("run-right", "deny-old-domain", ["domains"]);
+    const rightEnvironment = right.find(
+      (event) => event.name === "environment.snapshot",
+    );
+    if (rightEnvironment?.data) {
+      rightEnvironment.data = {
+        ...rightEnvironment.data,
+        node_version: "v25.0.0",
+        platform: "linux",
+      };
+    }
+
+    const comparison = compareRunEvents(left, right, {
+      leftRunId: "run-left",
+      rightRunId: "run-right",
+    });
+
+    expect(comparison.status).toBe("match");
+    expect(comparison.score.passed).toBe(true);
+    expect(comparison.context.diverged).toBeGreaterThan(0);
+    expect(comparison.left.environment).toMatchObject({
+      node_version: "v24.0.0",
+      platform: "darwin",
+    });
+    expect(comparison.right.environment).toMatchObject({
+      node_version: "v25.0.0",
+      platform: "linux",
+    });
+    expect(comparison.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "environment_node_version",
+          impact: "context",
+          status: "diverged",
+        }),
+        expect.objectContaining({
+          name: "environment_platform",
+          impact: "context",
+          status: "diverged",
+        }),
+      ]),
+    );
+  });
+
+  it("keeps old traces without environment snapshots compatible with new traces", () => {
+    const oldTrace = deniedTrace("run-left", "deny-old-domain", [
+      "domains",
+    ]).filter((event) => event.name !== "environment.snapshot");
+    const newTrace = deniedTrace("run-right", "deny-old-domain", ["domains"]);
+
+    const comparison = compareRunEvents(oldTrace, newTrace, {
+      leftRunId: "run-left",
+      rightRunId: "run-right",
+    });
+
+    expect(comparison.status).toBe("match");
+    expect(comparison.score.overall).toBe(1);
+    expect(comparison.context.unknown).toBe(0);
+    expect(comparison.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "environment_node_version",
+          impact: "context",
+          status: "match",
+        }),
+      ]),
+    );
   });
 });

--- a/tests/unit/session-events.test.ts
+++ b/tests/unit/session-events.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  createEnvironmentSnapshotEvent,
   createEvidenceCapturedEvent,
   createPermissionEvaluatedEvent,
   createRunEventSequence,
@@ -42,6 +43,42 @@ describe("session event builders", () => {
       visibility: "internal",
       metadata,
     });
+  });
+
+  it("builds environment snapshots as public reproducibility context", () => {
+    const sequence = createRunEventSequence();
+    const event = createEnvironmentSnapshotEvent(metadata, sequence, {
+      schema_version: "1",
+      unicli_version: "0.217.0",
+      node_version: "v24.0.0",
+      platform: "darwin",
+      arch: "arm64",
+      ci: false,
+      permission_profile: "locked",
+      transport_surface: "cli",
+      target_surface: "web",
+      pipeline_steps: 2,
+    });
+
+    expect(event).toMatchObject({
+      schema_version: "1",
+      name: "environment.snapshot",
+      visibility: "public",
+      data: {
+        schema_version: "1",
+        unicli_version: "0.217.0",
+        node_version: "v24.0.0",
+        platform: "darwin",
+        arch: "arm64",
+        ci: false,
+        permission_profile: "locked",
+        transport_surface: "cli",
+        target_surface: "web",
+        pipeline_steps: 2,
+      },
+    });
+    expect(event).not.toHaveProperty("internal");
+    expect(event).not.toHaveProperty("secret");
   });
 
   it("allocates monotonically increasing sequence numbers", () => {

--- a/tests/unit/session-run-loop.test.ts
+++ b/tests/unit/session-run-loop.test.ts
@@ -54,6 +54,8 @@ const fixture: AdapterManifest = {
 const originalRecordRun = process.env.UNICLI_RECORD_RUN;
 const originalRunRoot = process.env.UNICLI_RUN_ROOT;
 const originalPermissionRulesPath = process.env.UNICLI_PERMISSION_RULES_PATH;
+const originalCi = process.env.CI;
+const originalGithubActions = process.env.GITHUB_ACTIONS;
 
 describe("recorded run wrapper", () => {
   let tmp: string;
@@ -84,6 +86,16 @@ describe("recorded run wrapper", () => {
     } else {
       process.env.UNICLI_PERMISSION_RULES_PATH = originalPermissionRulesPath;
     }
+    if (originalCi === undefined) {
+      delete process.env.CI;
+    } else {
+      process.env.CI = originalCi;
+    }
+    if (originalGithubActions === undefined) {
+      delete process.env.GITHUB_ACTIONS;
+    } else {
+      process.env.GITHUB_ACTIONS = originalGithubActions;
+    }
   });
 
   it("returns the original InvocationResult while recording success events", async () => {
@@ -108,13 +120,16 @@ describe("recorded run wrapper", () => {
     const events = await readRunEvents(store, "run-success");
     expect(events.map((event) => event.name)).toEqual([
       "run.started",
+      "environment.snapshot",
       "tool.call.started",
       "permission.evaluated",
       "tool.call.completed",
       "evidence.captured",
       "run.completed",
     ]);
-    expect(events.map((event) => event.sequence)).toEqual([1, 2, 3, 4, 5, 6]);
+    expect(events.map((event) => event.sequence)).toEqual([
+      1, 2, 3, 4, 5, 6, 7,
+    ]);
     expect(events[0].metadata).toMatchObject({
       command: "session-fixture.read",
       adapter_path: "src/adapters/session-fixture/read.yaml",
@@ -122,6 +137,22 @@ describe("recorded run wrapper", () => {
       transport_surface: "cli",
       target_surface: "web",
     });
+    expect(events[1].data).toMatchObject({
+      schema_version: "1",
+      node_version: process.version,
+      platform: process.platform,
+      arch: process.arch,
+      ci: Boolean(process.env.CI || process.env.GITHUB_ACTIONS),
+      permission_profile: "open",
+      transport_surface: "cli",
+      target_surface: "web",
+      pipeline_steps: 0,
+    });
+    expect(typeof events[1].data?.unicli_version).toBe("string");
+    expect(events[1].visibility).toBe("public");
+    expect(events[1]).not.toHaveProperty("internal");
+    expect(events[1]).not.toHaveProperty("secret");
+    expect(JSON.stringify(events[1])).not.toContain(tmp);
   });
 
   it("records failure events with adapter path and error envelope", async () => {
@@ -141,6 +172,7 @@ describe("recorded run wrapper", () => {
     const events = await readRunEvents(store, "run-failed");
     expect(events.map((event) => event.name)).toEqual([
       "run.started",
+      "environment.snapshot",
       "tool.call.started",
       "permission.evaluated",
       "tool.call.failed",
@@ -156,6 +188,28 @@ describe("recorded run wrapper", () => {
         adapter_path: "src/adapters/session-fixture/fail.yaml",
       },
     });
+  });
+
+  it("does not treat false-like CI environment values as active CI", async () => {
+    const store = createRunStore({ rootDir: join(tmp, "runs") });
+    process.env.CI = "false";
+    process.env.GITHUB_ACTIONS = "0";
+    const inv = buildInvocation("cli", "session-fixture", "read", {
+      args: {},
+      source: "shell",
+    })!;
+
+    await executeWithRunRecording(inv, {
+      enabled: true,
+      store,
+      runId: "run-ci-false",
+    });
+
+    const events = await readRunEvents(store, "run-ci-false");
+    const environment = events.find(
+      (event) => event.name === "environment.snapshot",
+    );
+    expect(environment?.data?.ci).toBe(false);
   });
 
   it("records runtime permission denies as redacted trace decisions", async () => {
@@ -194,6 +248,7 @@ describe("recorded run wrapper", () => {
     const events = await readRunEvents(store, "run-runtime-denied");
     expect(events.map((event) => event.name)).toEqual([
       "run.started",
+      "environment.snapshot",
       "tool.call.started",
       "permission.evaluated",
       "permission.runtime_denied",
@@ -202,7 +257,7 @@ describe("recorded run wrapper", () => {
       "run.failed",
     ]);
     expect(events.map((event) => event.sequence)).toEqual([
-      1, 2, 3, 4, 5, 6, 7,
+      1, 2, 3, 4, 5, 6, 7, 8,
     ]);
     const runtimeDenied = events.find(
       (event) => event.name === "permission.runtime_denied",


### PR DESCRIPTION
## Summary
- record public environment.snapshot events for run-loop and browser action traces
- compare environment fields as reproducibility context without penalizing old traces
- add regression coverage for CI flag parsing, browser traces, old/new trace compare compatibility

## Verification
- pnpm exec vitest run --project unit tests/unit/session-run-loop.test.ts tests/unit/session-compare.test.ts tests/unit/commands/browser.test.ts
- pnpm format
- pnpm typecheck
- pnpm lint
- pnpm build
- pnpm verify:clean
- pre-push hook: pnpm verify:clean

## Review
- independent subagent review found 3 issues; fixed all in this branch