### PR TITLE
feat: report run score gates

### DIFF
--- a/.changeset/run-score-gate-output.md
+++ b/.changeset/run-score-gate-output.md
@@ -1,0 +1,5 @@
+---
+"@zenalexa/unicli": minor
+---
+
+Add structured `gate` results to run replay and compare score thresholds.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 </p>
 
 <p align="center">
-  <sub><!-- STATS:site_count -->235<!-- /STATS --> sites · <!-- STATS:command_count -->1448<!-- /STATS --> commands · <!-- STATS:pipeline_step_count -->59<!-- /STATS --> pipeline steps · <!-- STATS:test_count -->7578<!-- /STATS --> tests</sub>
+  <sub><!-- STATS:site_count -->235<!-- /STATS --> sites · <!-- STATS:command_count -->1448<!-- /STATS --> commands · <!-- STATS:pipeline_step_count -->59<!-- /STATS --> pipeline steps · <!-- STATS:test_count -->7582<!-- /STATS --> tests</sub>
 </p>
 
 <p align="center">
@@ -131,17 +131,17 @@ Prefer native CLI / JSON stream / MCP for agent runtimes. Use ACP as an editor c
 
 Uni-CLI sits under agent applications and turns software surfaces into commands that agents can discover, execute, record, and repair.
 
-| Surface            | What you get                                                                                                                                                                    |
-| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Websites and APIs  | Declarative adapters for public, cookie, header, and browser-intercept workflows                                                                                                |
-| Browser automation | CDP steps for navigate, click, type, intercept, snapshot, extract, wait, and related browser work                                                                               |
-| Desktop and macOS  | System commands, app adapters, screenshots, clipboard, calendar, brightness, and local tools                                                                                    |
-| External CLIs      | 58 registered pass-through bridges with install/status discovery                                                                                                                |
-| Agent backends     | Route matrix for native CLI, JSON stream, MCP, ACP, HTTP API, OpenAI-compatible, and bridge routes                                                                              |
-| Operation policy   | `open`, `confirm`, and `locked` profiles with effect/risk scopes, local deny rules, `--yes`, and persisted approval memory                                                      |
-| Evidence           | Run traces with environment snapshots, probe/replay/compare scores, browser session leases with tab/auth posture, render-aware evidence, movement checks, and stale-ref details |
-| Output             | v2 `AgentEnvelope` in Markdown, JSON, YAML, CSV, or compact format                                                                                                              |
-| Repair             | Structured errors with `adapter_path`, failing `step`, retryability, suggestions, and alternatives                                                                              |
+| Surface            | What you get                                                                                                                                                                                             |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Websites and APIs  | Declarative adapters for public, cookie, header, and browser-intercept workflows                                                                                                                         |
+| Browser automation | CDP steps for navigate, click, type, intercept, snapshot, extract, wait, and related browser work                                                                                                        |
+| Desktop and macOS  | System commands, app adapters, screenshots, clipboard, calendar, brightness, and local tools                                                                                                             |
+| External CLIs      | 58 registered pass-through bridges with install/status discovery                                                                                                                                         |
+| Agent backends     | Route matrix for native CLI, JSON stream, MCP, ACP, HTTP API, OpenAI-compatible, and bridge routes                                                                                                       |
+| Operation policy   | `open`, `confirm`, and `locked` profiles with effect/risk scopes, local deny rules, `--yes`, and persisted approval memory                                                                               |
+| Evidence           | Run traces with environment snapshots, probe/replay/compare scores, structured gate results, browser session leases with tab/auth posture, render-aware evidence, movement checks, and stale-ref details |
+| Output             | v2 `AgentEnvelope` in Markdown, JSON, YAML, CSV, or compact format                                                                                                                                       |
+| Repair             | Structured errors with `adapter_path`, failing `step`, retryability, suggestions, and alternatives                                                                                                       |
 
 ## For Agents
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -28,7 +28,7 @@
 </p>
 
 <p align="center">
-  <sub><!-- STATS:site_count -->235<!-- /STATS --> 个站点 · <!-- STATS:command_count -->1448<!-- /STATS --> 条命令 · <!-- STATS:pipeline_step_count -->59<!-- /STATS --> 个 pipeline step · <!-- STATS:test_count -->7578<!-- /STATS --> 个测试</sub>
+  <sub><!-- STATS:site_count -->235<!-- /STATS --> 个站点 · <!-- STATS:command_count -->1448<!-- /STATS --> 条命令 · <!-- STATS:pipeline_step_count -->59<!-- /STATS --> 个 pipeline step · <!-- STATS:test_count -->7582<!-- /STATS --> 个测试</sub>
 </p>
 
 <p align="center">
@@ -131,17 +131,17 @@ Prefer native CLI / JSON stream / MCP for agent runtimes. Use ACP as an editor c
 
 Uni-CLI 位于 Agent 应用之下，把软件表面收敛成 Agent 能发现、能执行、能记录、能修的命令。
 
-| 表面         | 能力                                                                                                                                                 |
-| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 网站和 API   | public、cookie、header、browser-intercept 等 adapter                                                                                                 |
-| 浏览器自动化 | CDP 的 navigate、click、type、intercept、snapshot、extract、wait 等步骤                                                                              |
-| 桌面和 macOS | 系统命令、App adapter、截图、剪贴板、日历、亮度、本地工具                                                                                            |
-| 外部 CLI     | 58 个已登记的 passthrough bridge，支持安装和状态发现                                                                                                 |
-| Agent 后端   | native CLI、JSON stream、MCP、ACP、HTTP API、OpenAI-compatible、bridge 路由矩阵                                                                      |
-| 操作策略     | `open`、`confirm`、`locked` profile，暴露 effect/risk scope、本地 deny 规则、`--yes` 和持久审批记忆                                                  |
-| 执行证据     | run trace 会记录环境快照，也能 probe/replay/compare 打分；浏览器 session lease 带 tab/auth 姿态，还支持 render-aware 证据、移动检测和 stale-ref 细节 |
-| 输出         | v2 `AgentEnvelope`，支持 Markdown、JSON、YAML、CSV、compact                                                                                          |
-| 修复         | 错误里带 `adapter_path`、失败 `step`、是否可重试、修复建议和替代命令                                                                                 |
+| 表面         | 能力                                                                                                                                                                       |
+| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 网站和 API   | public、cookie、header、browser-intercept 等 adapter                                                                                                                       |
+| 浏览器自动化 | CDP 的 navigate、click、type、intercept、snapshot、extract、wait 等步骤                                                                                                    |
+| 桌面和 macOS | 系统命令、App adapter、截图、剪贴板、日历、亮度、本地工具                                                                                                                  |
+| 外部 CLI     | 58 个已登记的 passthrough bridge，支持安装和状态发现                                                                                                                       |
+| Agent 后端   | native CLI、JSON stream、MCP、ACP、HTTP API、OpenAI-compatible、bridge 路由矩阵                                                                                            |
+| 操作策略     | `open`、`confirm`、`locked` profile，暴露 effect/risk scope、本地 deny 规则、`--yes` 和持久审批记忆                                                                        |
+| 执行证据     | run trace 会记录环境快照，也能 probe/replay/compare 打分并输出结构化 gate 结果；浏览器 session lease 带 tab/auth 姿态，还支持 render-aware 证据、移动检测和 stale-ref 细节 |
+| 输出         | v2 `AgentEnvelope`，支持 Markdown、JSON、YAML、CSV、compact                                                                                                                |
+| 修复         | 错误里带 `adapter_path`、失败 `step`、是否可重试、修复建议和替代命令                                                                                                       |
 
 ## 给 Agent 的入口
 

--- a/contributing/COPY.md
+++ b/contributing/COPY.md
@@ -2,7 +2,7 @@
 
 > Current version: v0.217.0 — Apollo · Lovell.
 >
-> Current scale: <!-- STATS:site_count -->235<!-- /STATS --> sites, <!-- STATS:command_count -->1448<!-- /STATS --> commands, <!-- STATS:adapter_count_total -->1039<!-- /STATS --> adapters (<!-- STATS:adapter_count_yaml -->917<!-- /STATS --> YAML + <!-- STATS:adapter_count_ts -->122<!-- /STATS --> TS), <!-- STATS:test_count -->7578<!-- /STATS --> tests.
+> Current scale: <!-- STATS:site_count -->235<!-- /STATS --> sites, <!-- STATS:command_count -->1448<!-- /STATS --> commands, <!-- STATS:adapter_count_total -->1039<!-- /STATS --> adapters (<!-- STATS:adapter_count_yaml -->917<!-- /STATS --> YAML + <!-- STATS:adapter_count_ts -->122<!-- /STATS --> TS), <!-- STATS:test_count -->7582<!-- /STATS --> tests.
 
 This file keeps docs and user-facing copy consistent. Public pages should expose
 install, command, output, and repair facts with the fewest words needed.

--- a/docs/adapters-catalog.json
+++ b/docs/adapters-catalog.json
@@ -1,6 +1,6 @@
 {
   "source": "unicli@0.217.0",
-  "generated": "2026-04-29T07:42:31.766Z",
+  "generated": "2026-04-29T08:00:18.483Z",
   "total_sites": 235,
   "total_commands": 1448,
   "adapters": [

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -137,6 +137,8 @@ unicli operate screenshot --path ./page.png
 Browser actions can attach before/after evidence, stale-ref detail, movement
 dimensions, watchdog results, session lease metadata, tab target identity,
 cookie posture, and render-aware reads when a command needs reviewable proof.
+When score thresholds are set, replay and compare output a `gate` object with
+the thresholds, actual scores, and failed gates.
 
 ```bash
 unicli browser evidence --render-aware --expect-domain example.com

--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -229,6 +229,8 @@ unicli operate screenshot --path ./page.png
 Browser actions can attach before/after evidence, stale-ref detail, movement
 dimensions, watchdog results, session lease metadata, tab target identity,
 cookie posture, and render-aware reads when a command needs reviewable proof.
+When score thresholds are set, replay and compare output a `gate` object with
+the thresholds, actual scores, and failed gates.
 
 ```bash
 unicli browser evidence --render-aware --expect-domain example.com

--- a/docs/public/markdown/guide/getting-started.md
+++ b/docs/public/markdown/guide/getting-started.md
@@ -144,6 +144,8 @@ unicli operate screenshot --path ./page.png
 Browser actions can attach before/after evidence, stale-ref detail, movement
 dimensions, watchdog results, session lease metadata, tab target identity,
 cookie posture, and render-aware reads when a command needs reviewable proof.
+When score thresholds are set, replay and compare output a `gate` object with
+the thresholds, actual scores, and failed gates.
 
 ```bash
 unicli browser evidence --render-aware --expect-domain example.com

--- a/docs/public/markdown/zh/guide/getting-started.md
+++ b/docs/public/markdown/zh/guide/getting-started.md
@@ -122,6 +122,7 @@ unicli operate screenshot --path ./page.png
 
 浏览器动作可以附带前后证据、stale-ref 细节、移动维度、watchdog 结果、
 session lease、tab 目标身份、cookie 姿态和 render-aware 读取，方便审查。
+设置分数阈值时，replay 和 compare 会输出 `gate` 对象，里面有阈值、实际分数和失败的 gate。
 
 ```bash
 unicli browser evidence --render-aware --expect-domain example.com

--- a/docs/site-index.json
+++ b/docs/site-index.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-04-29T07:42:31.766Z",
+  "generated": "2026-04-29T08:00:18.483Z",
   "total_sites": 235,
   "total_commands": 1448,
   "sites": [

--- a/docs/zh/guide/getting-started.md
+++ b/docs/zh/guide/getting-started.md
@@ -115,6 +115,7 @@ unicli operate screenshot --path ./page.png
 
 浏览器动作可以附带前后证据、stale-ref 细节、移动维度、watchdog 结果、
 session lease、tab 目标身份、cookie 姿态和 render-aware 读取，方便审查。
+设置分数阈值时，replay 和 compare 会输出 `gate` 对象，里面有阈值、实际分数和失败的 gate。
 
 ```bash
 unicli browser evidence --render-aware --expect-domain example.com

--- a/src/commands/runs.ts
+++ b/src/commands/runs.ts
@@ -76,6 +76,17 @@ interface RunsScoreThresholds {
   overall?: number;
 }
 
+interface RunsScoreGateResult {
+  passed: boolean;
+  failed: Array<keyof RunsScoreThresholds>;
+  thresholds: RunsScoreThresholds;
+  scores: {
+    behavior: number;
+    context: number;
+    overall: number;
+  };
+}
+
 function fmt(program: Command): OutputFormat {
   return detectFormat(program.opts().format as OutputFormat | undefined);
 }
@@ -112,7 +123,9 @@ function runStoreAgentErrorCode(error: RunStoreError): string {
 
 function scoreThreshold(value: string | undefined): number | undefined {
   if (value === undefined) return undefined;
-  const parsed = Number(value);
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return undefined;
+  const parsed = Number(trimmed);
   if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return undefined;
   return parsed;
 }
@@ -163,26 +176,39 @@ function parseScoreThresholds(
   };
 }
 
-function applyScoreThresholds(
+function scoreGateResult(
   comparison: ReturnType<typeof compareRunEvents>,
   thresholds: RunsScoreThresholds,
-): void {
+): RunsScoreGateResult | undefined {
+  if (Object.keys(thresholds).length === 0) return undefined;
+  const scores = {
+    behavior: comparison.score.behavior.score,
+    context: comparison.score.context.score,
+    overall: comparison.score.overall,
+  };
+  const failed: Array<keyof RunsScoreThresholds> = [];
   if (
     thresholds.behavior !== undefined &&
-    comparison.score.behavior.score < thresholds.behavior
+    scores.behavior < thresholds.behavior
   ) {
-    process.exitCode = 1;
+    failed.push("behavior");
   }
-  if (
-    thresholds.context !== undefined &&
-    comparison.score.context.score < thresholds.context
-  ) {
-    process.exitCode = 1;
+  if (thresholds.context !== undefined && scores.context < thresholds.context) {
+    failed.push("context");
   }
-  if (
-    thresholds.overall !== undefined &&
-    comparison.score.overall < thresholds.overall
-  ) {
+  if (thresholds.overall !== undefined && scores.overall < thresholds.overall) {
+    failed.push("overall");
+  }
+  return {
+    passed: failed.length === 0,
+    failed,
+    thresholds,
+    scores,
+  };
+}
+
+function applyScoreGate(gate: RunsScoreGateResult | undefined): void {
+  if (gate && !gate.passed) {
     process.exitCode = 1;
   }
 }
@@ -360,15 +386,16 @@ export function registerRunsCommand(program: Command): void {
           leftRunId,
           rightRunId,
         });
+        const gate = scoreGateResult(comparison, thresholds);
         console.log(
           format(
-            { ...comparison },
+            { ...comparison, ...(gate ? { gate } : {}) },
             undefined,
             fmt(program),
             makeCtx("runs.compare", startedAt),
           ),
         );
-        applyScoreThresholds(comparison, thresholds);
+        applyScoreGate(gate);
       },
     );
 
@@ -506,6 +533,7 @@ export function registerRunsCommand(program: Command): void {
         leftRunId: runId,
         rightRunId: replayRunId,
       });
+      const gate = scoreGateResult(comparison, thresholds);
       console.log(
         format(
           {
@@ -528,12 +556,13 @@ export function registerRunsCommand(program: Command): void {
               warnings: result.warnings,
             },
             comparison,
+            ...(gate ? { gate } : {}),
           },
           undefined,
           fmt(program),
           makeCtx("runs.replay", startedAt),
         ),
       );
-      applyScoreThresholds(comparison, thresholds);
+      applyScoreGate(gate);
     });
 }

--- a/stats.json
+++ b/stats.json
@@ -4,7 +4,7 @@
   "adapter_count_total": 1039,
   "site_count": 235,
   "command_count": 1448,
-  "test_count": 7578,
+  "test_count": 7582,
   "pipeline_step_count": 59,
   "transport_count": 3,
   "app_transport_count": 7,

--- a/tests/unit/session-runs-command.test.ts
+++ b/tests/unit/session-runs-command.test.ts
@@ -868,6 +868,12 @@ describe("unicli runs command", () => {
       ok: boolean;
       data: {
         result: { exit_code: number; result_count: number };
+        gate: {
+          passed: boolean;
+          failed: string[];
+          thresholds: { behavior: number };
+          scores: { behavior: number };
+        };
         comparison: {
           status: string;
           score: {
@@ -889,7 +895,68 @@ describe("unicli runs command", () => {
     expect(env.data.comparison.score.failed_behavior_checks).toContain(
       "result_count",
     );
+    expect(env.data.gate).toMatchObject({
+      passed: false,
+      failed: ["behavior"],
+      thresholds: { behavior: 1 },
+    });
+    expect(env.data.gate.scores.behavior).toBeLessThan(1);
     expect(process.exitCode).toBe(1);
+    expect(cap.getStdout()).not.toContain("hello replay");
+  });
+
+  it("emits a passed gate when replay score thresholds are met", async () => {
+    const rootDir = join(tmp, "runs");
+    const runId = await writeReplayableRun(rootDir);
+
+    const cap = captureConsole();
+    try {
+      const program = createProgram();
+      await program.parseAsync(
+        [
+          "-f",
+          "json",
+          "runs",
+          "replay",
+          runId,
+          "--root",
+          rootDir,
+          "--replay-run-id",
+          "run-replayed-01",
+          "--min-score",
+          "1",
+          "--min-context-score",
+          "1",
+          "--min-overall-score",
+          "1",
+        ],
+        { from: "user" },
+      );
+    } finally {
+      cap.restore();
+    }
+
+    const env = JSON.parse(cap.getStdout().trim()) as {
+      ok: boolean;
+      data: {
+        gate: {
+          passed: boolean;
+          failed: string[];
+          thresholds: { behavior: number; context: number; overall: number };
+          scores: { behavior: number; context: number; overall: number };
+        };
+        comparison: { status: string };
+      };
+    };
+    expect(env.ok).toBe(true);
+    expect(env.data.comparison.status).toBe("match");
+    expect(env.data.gate).toEqual({
+      passed: true,
+      failed: [],
+      thresholds: { behavior: 1, context: 1, overall: 1 },
+      scores: { behavior: 1, context: 1, overall: 1 },
+    });
+    expect(process.exitCode).toBeUndefined();
     expect(cap.getStdout()).not.toContain("hello replay");
   });
 
@@ -926,6 +993,12 @@ describe("unicli runs command", () => {
     const env = JSON.parse(cap.getStdout().trim()) as {
       ok: boolean;
       data: {
+        gate: {
+          passed: boolean;
+          failed: string[];
+          thresholds: { context: number };
+          scores: { context: number };
+        };
         comparison: {
           status: string;
           context: { diverged: number };
@@ -946,6 +1019,12 @@ describe("unicli runs command", () => {
         }),
       ]),
     );
+    expect(env.data.gate).toMatchObject({
+      passed: false,
+      failed: ["context"],
+      thresholds: { context: 1 },
+    });
+    expect(env.data.gate.scores.context).toBeLessThan(1);
     expect(process.exitCode).toBe(1);
     expect(cap.getStdout()).not.toContain("hello replay");
   });
@@ -983,6 +1062,12 @@ describe("unicli runs command", () => {
     const env = JSON.parse(cap.getStdout().trim()) as {
       ok: boolean;
       data: {
+        gate: {
+          passed: boolean;
+          failed: string[];
+          thresholds: { overall: number };
+          scores: { overall: number };
+        };
         comparison: {
           status: string;
           score: { overall: number; context: { score: number } };
@@ -993,8 +1078,38 @@ describe("unicli runs command", () => {
     expect(env.data.comparison.status).toBe("match");
     expect(env.data.comparison.score.context.score).toBeLessThan(1);
     expect(env.data.comparison.score.overall).toBeLessThan(1);
+    expect(env.data.gate).toMatchObject({
+      passed: false,
+      failed: ["overall"],
+      thresholds: { overall: 1 },
+    });
+    expect(env.data.gate.scores.overall).toBeLessThan(1);
     expect(process.exitCode).toBe(1);
     expect(cap.getStdout()).not.toContain("hello replay");
+  });
+
+  it("rejects empty replay score thresholds", async () => {
+    const cap = captureConsole();
+    try {
+      const program = createProgram();
+      await program.parseAsync(
+        ["-f", "json", "runs", "replay", "run-any", "--min-score", ""],
+        { from: "user" },
+      );
+    } finally {
+      cap.restore();
+    }
+
+    const env = JSON.parse(cap.getStdout().trim()) as {
+      ok: boolean;
+      error: { code: string; message: string };
+    };
+    expect(env.ok).toBe(false);
+    expect(env.error).toMatchObject({
+      code: "invalid_input",
+      message: "--min-score must be a number between 0 and 1",
+    });
+    expect(process.exitCode).toBe(ExitCode.USAGE_ERROR);
   });
 
   it("compares replay traces without exposing argument values", async () => {
@@ -1063,6 +1178,64 @@ describe("unicli runs command", () => {
         expect.objectContaining({ name: "result_count", status: "match" }),
       ]),
     );
+    expect(cap.getStdout()).not.toContain("hello replay");
+  });
+
+  it("emits a passed gate when compare score thresholds are met", async () => {
+    const rootDir = join(tmp, "runs");
+    const runId = await writeReplayableRun(rootDir);
+    const identicalRunId = await writeReplayableRun(rootDir, {
+      runId: "run-replayable-02",
+      traceId: "01HTRACEREPLAY0000000002",
+    });
+
+    const cap = captureConsole();
+    try {
+      const program = createProgram();
+      await program.parseAsync(
+        [
+          "-f",
+          "json",
+          "runs",
+          "compare",
+          runId,
+          identicalRunId,
+          "--root",
+          rootDir,
+          "--min-score",
+          "1",
+          "--min-context-score",
+          "1",
+          "--min-overall-score",
+          "1",
+        ],
+        { from: "user" },
+      );
+    } finally {
+      cap.restore();
+    }
+
+    const env = JSON.parse(cap.getStdout().trim()) as {
+      ok: boolean;
+      data: {
+        status: string;
+        gate: {
+          passed: boolean;
+          failed: string[];
+          thresholds: { behavior: number; context: number; overall: number };
+          scores: { behavior: number; context: number; overall: number };
+        };
+      };
+    };
+    expect(env.ok).toBe(true);
+    expect(env.data.status).toBe("match");
+    expect(env.data.gate).toEqual({
+      passed: true,
+      failed: [],
+      thresholds: { behavior: 1, context: 1, overall: 1 },
+      scores: { behavior: 1, context: 1, overall: 1 },
+    });
+    expect(process.exitCode).toBeUndefined();
     expect(cap.getStdout()).not.toContain("hello replay");
   });
 
@@ -1144,6 +1317,12 @@ describe("unicli runs command", () => {
       ok: boolean;
       data: {
         status: string;
+        gate: {
+          passed: boolean;
+          failed: string[];
+          thresholds: { behavior: number };
+          scores: { behavior: number };
+        };
         score: {
           passed: boolean;
           behavior: { score: number };
@@ -1156,7 +1335,46 @@ describe("unicli runs command", () => {
     expect(env.data.score.passed).toBe(false);
     expect(env.data.score.behavior.score).toBeLessThan(1);
     expect(env.data.score.failed_behavior_checks.length).toBeGreaterThan(0);
+    expect(env.data.gate).toMatchObject({
+      passed: false,
+      failed: ["behavior"],
+      thresholds: { behavior: 1 },
+    });
+    expect(env.data.gate.scores.behavior).toBeLessThan(1);
     expect(process.exitCode).toBe(1);
+  });
+
+  it("rejects whitespace compare score thresholds", async () => {
+    const cap = captureConsole();
+    try {
+      const program = createProgram();
+      await program.parseAsync(
+        [
+          "-f",
+          "json",
+          "runs",
+          "compare",
+          "run-left",
+          "run-right",
+          "--min-context-score",
+          "   ",
+        ],
+        { from: "user" },
+      );
+    } finally {
+      cap.restore();
+    }
+
+    const env = JSON.parse(cap.getStdout().trim()) as {
+      ok: boolean;
+      error: { code: string; message: string };
+    };
+    expect(env.ok).toBe(false);
+    expect(env.error).toMatchObject({
+      code: "invalid_input",
+      message: "--min-context-score must be a number between 0 and 1",
+    });
+    expect(process.exitCode).toBe(ExitCode.USAGE_ERROR);
   });
 
   it("can fail CI when compare context score is below a threshold", async () => {
@@ -1194,6 +1412,12 @@ describe("unicli runs command", () => {
       ok: boolean;
       data: {
         status: string;
+        gate: {
+          passed: boolean;
+          failed: string[];
+          thresholds: { context: number };
+          scores: { context: number };
+        };
         behavior: { diverged: number };
         context: { diverged: number };
         score: {
@@ -1217,6 +1441,12 @@ describe("unicli runs command", () => {
         }),
       ]),
     );
+    expect(env.data.gate).toMatchObject({
+      passed: false,
+      failed: ["context"],
+      thresholds: { context: 1 },
+    });
+    expect(env.data.gate.scores.context).toBeLessThan(1);
     expect(process.exitCode).toBe(1);
   });
 
@@ -1255,6 +1485,12 @@ describe("unicli runs command", () => {
       ok: boolean;
       data: {
         status: string;
+        gate: {
+          passed: boolean;
+          failed: string[];
+          thresholds: { overall: number };
+          scores: { overall: number };
+        };
         behavior: { diverged: number };
         score: {
           overall: number;
@@ -1267,6 +1503,12 @@ describe("unicli runs command", () => {
     expect(env.data.behavior.diverged).toBe(0);
     expect(env.data.score.context.score).toBeLessThan(1);
     expect(env.data.score.overall).toBeLessThan(1);
+    expect(env.data.gate).toMatchObject({
+      passed: false,
+      failed: ["overall"],
+      thresholds: { overall: 1 },
+    });
+    expect(env.data.gate.scores.overall).toBeLessThan(1);
     expect(process.exitCode).toBe(1);
   });
 


### PR DESCRIPTION
## Summary
- add structured `gate` output when `runs replay` and `runs compare` score thresholds are set
- report pass/fail state, failed gates, thresholds, and behavior/context/overall scores
- reject empty or whitespace score threshold values before trace lookup

## Verification
- red test first: new empty-threshold tests failed because values were accepted as `0`
- `pnpm exec vitest run --project unit tests/unit/session-runs-command.test.ts`
- `pnpm format && pnpm verify:clean`
- pre-push `pnpm verify:clean`

## Review
- independent diff review found empty/whitespace threshold parsing and missing passed-gate coverage
- follow-up independent review reported no remaining findings