### PR TITLE
docs(release): record v0.400.0 publication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## [0.400.0] — 2026-07-17 — Apollo · Young
 
-> Local release: built and verified on this machine; no npm publication,
-> GitHub Release, or remote tag is represented.
+> Published from annotated tag `v0.400.0` at commit `3e4d555c` through GitHub
+> Actions run `29568815086`, using npm Trusted Publishers with SLSA provenance
+> and a GitHub Release carrying both Windows process-owner executables.
 
 ### Added
 

--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -81,7 +81,7 @@ These numbers come from the current generated repo artifacts: operations, adapte
 
 ## Current Version
 
-Local release: v0.400.0 · Apollo · Young.
+Latest: v0.400.0 · Apollo · Young.
 
 ## Agent Index
 
@@ -4114,16 +4114,20 @@ ancestor of `HEAD`, and checking that the first-class `macos app-actions` and
 
 ## Historical Release Audit
 
-The public git/tag history starts in 2026 with the `0.200.x` line. The
-`0.400.0` delivery is local: package and documentation metadata identify it
-as locally built and verified, not as an npm or GitHub publication.
+The public git/tag history starts in 2026 with the `0.200.x` line. Release
+`0.400.0 — Apollo · Young` is published on npm and GitHub from the exact
+annotated tag recorded below.
 
 Release facts:
 
-- npm registry state before local delivery:
-  `@zenalexa/unicli@latest` is `0.227.1`;
-- local package target: `0.400.0`; no release tag or remote publication is
-  represented;
+- npm registry state after publication:
+  `@zenalexa/unicli@latest` is `0.400.0`;
+- annotated tag `v0.400.0` resolves to main commit
+  `3e4d555c9641cc2dfd541373c391970d9d0972da`;
+- GitHub Actions run `29568815086` published through npm Trusted Publishers
+  without a fallback token, and the installed package verifies SLSA provenance;
+- the GitHub Release contains x64 and arm64 Windows process-owner executables
+  that are byte-identical to the corresponding files in the npm tarball;
 - the shared Browser Runtime Broker owns provider lifetime, Agent sessions,
   target leases, visibility, cancellation, and cleanup;
 - the generic computer-use profile exposes direct browser state, navigation,
@@ -4211,16 +4215,19 @@ RELEASE_CODENAME="Vostok · Gagarin" npm run release
 npm run release:check -- --strict-codename
 ```
 
-For the 0.400 line, the release label format is unchanged. The local release
-label is `Apollo · Young`.
+For the 0.400 line, the release label format is unchanged. The published
+release label is `Apollo · Young`.
 
-Local delivery uses an explicit `local` status. This is also the default, so
-generated docs cannot turn an unobserved npm or GitHub Release event into a
-publication claim:
+Candidate delivery uses the default `local` status, so generated docs cannot
+turn an unobserved npm or GitHub Release event into a publication claim. Only
+after both public endpoints are verified should metadata move to `published`:
 
 ```bash
-npx tsx scripts/release.ts --codename "Apollo · Young" --status local
+npx tsx scripts/release.ts --codename "Apollo · Young" --status published
 ```
+
+For `0.400.0`, that transition followed registry, provenance, Release asset,
+installed CLI, search, and stopped-browser doctor probes.
 
 ## Substantive Commits
 
@@ -4290,7 +4297,8 @@ To ship a release:
    `npm publish --dry-run`, and `npm run docs:check-public`.
 5. Commit the release candidate to `main`.
 6. Push `main`.
-7. Create the release tag with `git tag vX.Y.Z`.
+7. Create the annotated release tag with
+   `git tag -a vX.Y.Z -m "vX.Y.Z — Program · Astronaut"`.
 8. Push the tag with `git push origin vX.Y.Z`.
 9. Watch **Actions → Release**. The workflow checks out the tag, verifies the
    package surface, publishes to npm with provenance, and creates the GitHub

--- a/docs/public/markdown/index.md
+++ b/docs/public/markdown/index.md
@@ -63,7 +63,7 @@ These numbers come from the current generated repo artifacts: operations, adapte
 
 ## Current Version
 
-Local release: v0.400.0 · Apollo · Young.
+Latest: v0.400.0 · Apollo · Young.
 
 ## Agent Index
 

--- a/docs/public/markdown/reference/release.md
+++ b/docs/public/markdown/reference/release.md
@@ -54,16 +54,20 @@ ancestor of `HEAD`, and checking that the first-class `macos app-actions` and
 
 ## Historical Release Audit
 
-The public git/tag history starts in 2026 with the `0.200.x` line. The
-`0.400.0` delivery is local: package and documentation metadata identify it
-as locally built and verified, not as an npm or GitHub publication.
+The public git/tag history starts in 2026 with the `0.200.x` line. Release
+`0.400.0 — Apollo · Young` is published on npm and GitHub from the exact
+annotated tag recorded below.
 
 Release facts:
 
-- npm registry state before local delivery:
-  `@zenalexa/unicli@latest` is `0.227.1`;
-- local package target: `0.400.0`; no release tag or remote publication is
-  represented;
+- npm registry state after publication:
+  `@zenalexa/unicli@latest` is `0.400.0`;
+- annotated tag `v0.400.0` resolves to main commit
+  `3e4d555c9641cc2dfd541373c391970d9d0972da`;
+- GitHub Actions run `29568815086` published through npm Trusted Publishers
+  without a fallback token, and the installed package verifies SLSA provenance;
+- the GitHub Release contains x64 and arm64 Windows process-owner executables
+  that are byte-identical to the corresponding files in the npm tarball;
 - the shared Browser Runtime Broker owns provider lifetime, Agent sessions,
   target leases, visibility, cancellation, and cleanup;
 - the generic computer-use profile exposes direct browser state, navigation,
@@ -151,16 +155,19 @@ RELEASE_CODENAME="Vostok · Gagarin" npm run release
 npm run release:check -- --strict-codename
 ```
 
-For the 0.400 line, the release label format is unchanged. The local release
-label is `Apollo · Young`.
+For the 0.400 line, the release label format is unchanged. The published
+release label is `Apollo · Young`.
 
-Local delivery uses an explicit `local` status. This is also the default, so
-generated docs cannot turn an unobserved npm or GitHub Release event into a
-publication claim:
+Candidate delivery uses the default `local` status, so generated docs cannot
+turn an unobserved npm or GitHub Release event into a publication claim. Only
+after both public endpoints are verified should metadata move to `published`:
 
 ```bash
-npx tsx scripts/release.ts --codename "Apollo · Young" --status local
+npx tsx scripts/release.ts --codename "Apollo · Young" --status published
 ```
+
+For `0.400.0`, that transition followed registry, provenance, Release asset,
+installed CLI, search, and stopped-browser doctor probes.
 
 ## Substantive Commits
 
@@ -230,7 +237,8 @@ To ship a release:
    `npm publish --dry-run`, and `npm run docs:check-public`.
 5. Commit the release candidate to `main`.
 6. Push `main`.
-7. Create the release tag with `git tag vX.Y.Z`.
+7. Create the annotated release tag with
+   `git tag -a vX.Y.Z -m "vX.Y.Z — Program · Astronaut"`.
 8. Push the tag with `git push origin vX.Y.Z`.
 9. Watch **Actions → Release**. The workflow checks out the tag, verifies the
    package surface, publishes to npm with provenance, and creates the GitHub

--- a/docs/public/markdown/zh/index.md
+++ b/docs/public/markdown/zh/index.md
@@ -63,7 +63,7 @@ Agent 执行需要的不是更长的常驻工具列表，也不是又一个网�
 
 ## 当前版本
 
-本地版本：v0.400.0 · Apollo · Young。
+当前 latest：v0.400.0 · Apollo · Young。
 
 ## Agent 索引
 

--- a/docs/public/markdown/zh/reference/release.md
+++ b/docs/public/markdown/zh/reference/release.md
@@ -47,7 +47,7 @@ npm run release:check
 ## 历史发布审计
 
 当前公开 git/tag 历史从 2026 年的 `0.200.x` 线开始。`0.400.0 — Apollo · Young`
-已经从下述精确 annotated tag 发布到 npm 与 GitHub。
+已经从下述精确的 annotated tag 发布到 npm 与 GitHub。
 
 交付事实：
 

--- a/docs/public/markdown/zh/reference/release.md
+++ b/docs/public/markdown/zh/reference/release.md
@@ -46,14 +46,18 @@ npm run release:check
 
 ## 历史发布审计
 
-当前公开 git/tag 历史从 2026 年的 `0.200.x` 线开始。`0.400.0` 是本机交付：
-package 与文档元数据只将它标记为已在本机构建并验证，不表示 npm 或 GitHub
-Release 已发布。
+当前公开 git/tag 历史从 2026 年的 `0.200.x` 线开始。`0.400.0 — Apollo · Young`
+已经从下述精确 annotated tag 发布到 npm 与 GitHub。
 
 交付事实：
 
-- 本机交付前，npm registry 上 `@zenalexa/unicli@latest` 是 `0.227.1`；
-- 本机 package 目标为 `0.400.0`；没有创建远端 tag，也没有表示已完成远端发布；
+- 发布后，npm registry 上 `@zenalexa/unicli@latest` 是 `0.400.0`；
+- annotated tag `v0.400.0` 指向 main commit
+  `3e4d555c9641cc2dfd541373c391970d9d0972da`；
+- GitHub Actions run `29568815086` 通过 npm Trusted Publishers 发布，没有使用
+  fallback token；安装后的包已通过 SLSA provenance 验证；
+- GitHub Release 中的 x64 与 arm64 Windows process-owner 可执行文件，与 npm
+  tarball 内对应文件逐字节一致；
 - 共享 Browser Runtime Broker 统一负责 provider 生命周期、Agent session、target lease、可见性、取消和清理；
 - 通用 computer-use profile 暴露直接的浏览器 state、navigation、可信 input、tab、有界内容/历史搜索、dialog、download 和显式前台 presence；
 - Windows Native Messaging 使用架构匹配的 PE launcher 和不可变、并行存在的 generation，重装或升级不会替换活跃 Chrome host 正在使用的可执行文件；
@@ -105,7 +109,7 @@ npm run changeset
 | `0.200-0.213` | Vostok  |
 | `0.216+`      | Apollo  |
 
-`0.400.0` 的本机发布 label 是 `Apollo · Young`。
+`0.400.0` 的已发布 label 是 `Apollo · Young`。
 
 ## 发布步骤
 
@@ -124,11 +128,16 @@ npm run docs:check-public
 - changelog 说清楚用户能得到什么。
 - 产品模型重塑发布要更新本页的历史发布审计。
 
-本机交付使用显式 `local` 状态；`scripts/release.ts` 默认也是 `local`，因此生成文档不会把尚未发生的 npm 或 GitHub Release 事件写成既成事实：
+候选交付使用默认的 `local` 状态，因此生成文档不会把尚未发生的 npm 或 GitHub
+Release 写成既成事实。只有两个公开端点都验证通过后，元数据才切换到
+`published`：
 
 ```bash
-npx tsx scripts/release.ts --codename "Apollo · Young" --status local
+npx tsx scripts/release.ts --codename "Apollo · Young" --status published
 ```
+
+`0.400.0` 的切换发生在 registry、provenance、Release asset、安装后 CLI、搜索和
+浏览器保持 stopped 的 doctor probe 全部通过之后。
 
 真实发布步骤：
 
@@ -137,7 +146,7 @@ git status --short
 git add <release files>
 git commit -m "chore(release): vX.Y.Z"
 git push origin main
-git tag vX.Y.Z
+git tag -a vX.Y.Z -m "vX.Y.Z — Program · Astronaut"
 git push origin vX.Y.Z
 ```
 

--- a/docs/reference/release.md
+++ b/docs/reference/release.md
@@ -47,16 +47,20 @@ ancestor of `HEAD`, and checking that the first-class `macos app-actions` and
 
 ## Historical Release Audit
 
-The public git/tag history starts in 2026 with the `0.200.x` line. The
-`0.400.0` delivery is local: package and documentation metadata identify it
-as locally built and verified, not as an npm or GitHub publication.
+The public git/tag history starts in 2026 with the `0.200.x` line. Release
+`0.400.0 — Apollo · Young` is published on npm and GitHub from the exact
+annotated tag recorded below.
 
 Release facts:
 
-- npm registry state before local delivery:
-  `@zenalexa/unicli@latest` is `0.227.1`;
-- local package target: `0.400.0`; no release tag or remote publication is
-  represented;
+- npm registry state after publication:
+  `@zenalexa/unicli@latest` is `0.400.0`;
+- annotated tag `v0.400.0` resolves to main commit
+  `3e4d555c9641cc2dfd541373c391970d9d0972da`;
+- GitHub Actions run `29568815086` published through npm Trusted Publishers
+  without a fallback token, and the installed package verifies SLSA provenance;
+- the GitHub Release contains x64 and arm64 Windows process-owner executables
+  that are byte-identical to the corresponding files in the npm tarball;
 - the shared Browser Runtime Broker owns provider lifetime, Agent sessions,
   target leases, visibility, cancellation, and cleanup;
 - the generic computer-use profile exposes direct browser state, navigation,
@@ -144,16 +148,19 @@ RELEASE_CODENAME="Vostok · Gagarin" npm run release
 npm run release:check -- --strict-codename
 ```
 
-For the 0.400 line, the release label format is unchanged. The local release
-label is `Apollo · Young`.
+For the 0.400 line, the release label format is unchanged. The published
+release label is `Apollo · Young`.
 
-Local delivery uses an explicit `local` status. This is also the default, so
-generated docs cannot turn an unobserved npm or GitHub Release event into a
-publication claim:
+Candidate delivery uses the default `local` status, so generated docs cannot
+turn an unobserved npm or GitHub Release event into a publication claim. Only
+after both public endpoints are verified should metadata move to `published`:
 
 ```bash
-npx tsx scripts/release.ts --codename "Apollo · Young" --status local
+npx tsx scripts/release.ts --codename "Apollo · Young" --status published
 ```
+
+For `0.400.0`, that transition followed registry, provenance, Release asset,
+installed CLI, search, and stopped-browser doctor probes.
 
 ## Substantive Commits
 
@@ -223,7 +230,8 @@ To ship a release:
    `npm publish --dry-run`, and `npm run docs:check-public`.
 5. Commit the release candidate to `main`.
 6. Push `main`.
-7. Create the release tag with `git tag vX.Y.Z`.
+7. Create the annotated release tag with
+   `git tag -a vX.Y.Z -m "vX.Y.Z — Program · Astronaut"`.
 8. Push the tag with `git push origin vX.Y.Z`.
 9. Watch **Actions → Release**. The workflow checks out the tag, verifies the
    package surface, publishes to npm with provenance, and creates the GitHub

--- a/docs/release-info.json
+++ b/docs/release-info.json
@@ -2,7 +2,7 @@
   "version": "0.400.0",
   "codename": "Apollo · Young",
   "date": "2026-07-17",
-  "status": "local",
+  "status": "published",
   "npmPackage": "@zenalexa/unicli",
   "npmUrl": "https://www.npmjs.com/package/@zenalexa/unicli",
   "releaseUrl": "https://github.com/olo-dot-io/Uni-CLI/releases/tag/v0.400.0",
@@ -12,13 +12,13 @@
       "Uni-CLI 0.400.0 delivers one shared, background-first Browser Runtime Broker for managed, existing-Chrome, and remote providers with explicit Agent session and target ownership.",
       "The generic computer-use profile exposes 16 direct browser tools alongside 16 computer controls for state, screenshots, navigation, trusted refs, input, tabs, dialogs, downloads, search, and foreground presence.",
       "Bounded open-tab and history search runs without debugger attachment, focus changes, navigation, target claims, or persistent page-content indexing; sensitive and Agent-owned visual content stays excluded.",
-      "This metadata describes a locally built and verified release. It does not claim npm or GitHub Release publication."
+      "Published from annotated tag v0.400.0 through GitHub Actions run 29568815086 using npm Trusted Publishers with verified SLSA provenance and matching x64/arm64 Windows Release assets."
     ],
     "zh": [
       "Uni-CLI 0.400.0 交付一个共享、后台优先的 Browser Runtime Broker，统一托管 managed、现有 Chrome 与 remote provider，并显式隔离 Agent session 与 target ownership。",
       "通用 computer-use profile 现提供 16 个直接浏览器工具与 16 个电脑控制工具，覆盖 state、screenshot、navigation、可信 ref、input、tab、dialog、download、search 与前台 presence。",
       "有界的打开标签页与历史搜索不会附加 debugger、改变焦点、导航、认领 target 或持久索引页面内容；敏感内容和 Agent 自有视觉元素不会进入感知结果。",
-      "这里描述的是已在本机构建并验证的版本，不代表 npm 或 GitHub Release 已发布。"
+      "已从 annotated tag v0.400.0 通过 GitHub Actions run 29568815086 发布；npm Trusted Publishers 的 SLSA provenance 已验证，GitHub Release 的 x64/arm64 Windows 资产与 npm 包逐字节一致。"
     ]
   }
 }

--- a/docs/zh/reference/release.md
+++ b/docs/zh/reference/release.md
@@ -39,14 +39,18 @@ npm run release:check
 
 ## 历史发布审计
 
-当前公开 git/tag 历史从 2026 年的 `0.200.x` 线开始。`0.400.0` 是本机交付：
-package 与文档元数据只将它标记为已在本机构建并验证，不表示 npm 或 GitHub
-Release 已发布。
+当前公开 git/tag 历史从 2026 年的 `0.200.x` 线开始。`0.400.0 — Apollo · Young`
+已经从下述精确 annotated tag 发布到 npm 与 GitHub。
 
 交付事实：
 
-- 本机交付前，npm registry 上 `@zenalexa/unicli@latest` 是 `0.227.1`；
-- 本机 package 目标为 `0.400.0`；没有创建远端 tag，也没有表示已完成远端发布；
+- 发布后，npm registry 上 `@zenalexa/unicli@latest` 是 `0.400.0`；
+- annotated tag `v0.400.0` 指向 main commit
+  `3e4d555c9641cc2dfd541373c391970d9d0972da`；
+- GitHub Actions run `29568815086` 通过 npm Trusted Publishers 发布，没有使用
+  fallback token；安装后的包已通过 SLSA provenance 验证；
+- GitHub Release 中的 x64 与 arm64 Windows process-owner 可执行文件，与 npm
+  tarball 内对应文件逐字节一致；
 - 共享 Browser Runtime Broker 统一负责 provider 生命周期、Agent session、target lease、可见性、取消和清理；
 - 通用 computer-use profile 暴露直接的浏览器 state、navigation、可信 input、tab、有界内容/历史搜索、dialog、download 和显式前台 presence；
 - Windows Native Messaging 使用架构匹配的 PE launcher 和不可变、并行存在的 generation，重装或升级不会替换活跃 Chrome host 正在使用的可执行文件；
@@ -98,7 +102,7 @@ npm run changeset
 | `0.200-0.213` | Vostok  |
 | `0.216+`      | Apollo  |
 
-`0.400.0` 的本机发布 label 是 `Apollo · Young`。
+`0.400.0` 的已发布 label 是 `Apollo · Young`。
 
 ## 发布步骤
 
@@ -117,11 +121,16 @@ npm run docs:check-public
 - changelog 说清楚用户能得到什么。
 - 产品模型重塑发布要更新本页的历史发布审计。
 
-本机交付使用显式 `local` 状态；`scripts/release.ts` 默认也是 `local`，因此生成文档不会把尚未发生的 npm 或 GitHub Release 事件写成既成事实：
+候选交付使用默认的 `local` 状态，因此生成文档不会把尚未发生的 npm 或 GitHub
+Release 写成既成事实。只有两个公开端点都验证通过后，元数据才切换到
+`published`：
 
 ```bash
-npx tsx scripts/release.ts --codename "Apollo · Young" --status local
+npx tsx scripts/release.ts --codename "Apollo · Young" --status published
 ```
+
+`0.400.0` 的切换发生在 registry、provenance、Release asset、安装后 CLI、搜索和
+浏览器保持 stopped 的 doctor probe 全部通过之后。
 
 真实发布步骤：
 
@@ -130,7 +139,7 @@ git status --short
 git add <release files>
 git commit -m "chore(release): vX.Y.Z"
 git push origin main
-git tag vX.Y.Z
+git tag -a vX.Y.Z -m "vX.Y.Z — Program · Astronaut"
 git push origin vX.Y.Z
 ```
 

--- a/docs/zh/reference/release.md
+++ b/docs/zh/reference/release.md
@@ -40,7 +40,7 @@ npm run release:check
 ## 历史发布审计
 
 当前公开 git/tag 历史从 2026 年的 `0.200.x` 线开始。`0.400.0 — Apollo · Young`
-已经从下述精确 annotated tag 发布到 npm 与 GitHub。
+已经从下述精确的 annotated tag 发布到 npm 与 GitHub。
 
 交付事实：
 


### PR DESCRIPTION
## Summary

- switch `docs/release-info.json` from candidate-only `local` state to observed `published` state
- record the exact annotated tag, main commit, Trusted Publishers/SLSA provenance run, npm `latest` result, and byte-identical Windows assets in the changelog and English/Chinese release references
- document the verified installed CLI, search, and stopped-browser doctor probes and regenerate public agent documentation

## Public evidence

- npm: `@zenalexa/unicli@0.400.0`, `latest=0.400.0`
- annotated tag: `v0.400.0` → `3e4d555c9641cc2dfd541373c391970d9d0972da`
- release workflow: `29568815086` (`success`, OIDC Trusted Publishers, no fallback token)
- GitHub Release: https://github.com/olo-dot-io/Uni-CLI/releases/tag/v0.400.0
- verified SLSA provenance: `npm audit signatures --include-attestations`
- npm/GitHub x64 asset SHA-256: `5de1278105ee3d958ea3162ecaa817225a3f1d7bb644e3e43a75fd3f21ec21dc`
- npm/GitHub arm64 asset SHA-256: `9ae52b016e0ddfc39088138e934e37b8723bb60e1da86c30287ed6d0da5aefee`

## Verification

- `npm run docs:build` — 150 public files passed
- `npm run format:check`
- `npm run stats:check`
- `npm run boundary:check`
- `npm run truth:check`
- independent audit: Pass; regenerated `docs/public/**` was byte-identical